### PR TITLE
Feature/no spaces&dependency update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5819,9 +5819,12 @@
       }
     },
     "eslint-utils": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
-      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q=="
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+      "requires": {
+        "eslint-visitor-keys": "^1.0.0"
+      }
     },
     "eslint-visitor-keys": {
       "version": "1.0.0",
@@ -6853,9 +6856,9 @@
       "integrity": "sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ=="
     },
     "handlebars": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.0.tgz",
+      "integrity": "sha512-xkRtOt3/3DzTKMOt3xahj2M/EqNhY988T+imYSlMgs5fVhLN2fmKVVj0LtEGmb+3UUYV5Qmm1052Mm3dIQxOvw==",
       "requires": {
         "neo-async": "^2.6.0",
         "optimist": "^0.6.1",

--- a/src/actions/orderCartActions.js
+++ b/src/actions/orderCartActions.js
@@ -180,7 +180,7 @@ export function uploadOrderFile(collectionId, cartInfo) {
              // iterate all cart files since mulitple screenshot images permitted
              cartFiles.forEach((file, index) => {
                // build fake form to do the upload. required to use the s3 rest api
-               const fileKey = 'data-tnris-org-order/' + collectionId + '_' + Date.now() + '_' + file.name;
+               const fileKey = 'data-tnris-org-order/' + collectionId + '_' + Date.now() + '_' + file.name.split(' ').join('_');
                let formData = new FormData();
                formData.append('key', fileKey);
                formData.append('acl', 'private');


### PR DESCRIPTION
closes issue #198 ---> replace spaces in uploaded filenames with underscores; this is for collection partial orders where a zipped shapefile or image(s) is uploaded by the user.

threw in some dependency updates in there, reflected in package-lock.json