### PR TITLE
Feature/collection template reorg

### DIFF
--- a/src/components/Catalog.jsx
+++ b/src/components/Catalog.jsx
@@ -1,31 +1,31 @@
-import React from 'react';
-import { Redirect } from 'react-router';
-import { Route, Switch } from 'react-router';
-import { matchPath } from 'react-router-dom';
-import { MDCDrawer } from "@material/drawer";
-import { MDCSnackbar } from '@material/snackbar';
-import { MDCDialog } from '@material/dialog';
-import { GridLoader } from 'react-spinners';
+import React from 'react'
+import { Redirect } from 'react-router'
+import { Route, Switch } from 'react-router'
+import { matchPath } from 'react-router-dom'
+import { MDCDrawer } from "@material/drawer"
+import { MDCSnackbar } from '@material/snackbar'
+import { MDCDialog } from '@material/dialog'
+import { GridLoader } from 'react-spinners'
 
-import HistoricalAerialTemplate from './HistoricalAerialTemplate/HistoricalAerialTemplate';
-import OutsideEntityTemplate from './TnrisOutsideEntityTemplate/TnrisOutsideEntityTemplate';
-import TnrisOrderTemplate from './TnrisOrderTemplate/TnrisOrderTemplate';
+import HistoricalAerialTemplate from './HistoricalAerialTemplate/HistoricalAerialTemplate'
+import OutsideEntityTemplate from './TnrisOutsideEntityTemplate/TnrisOutsideEntityTemplate'
+import TnrisOrderTemplate from './TnrisOrderTemplate/TnrisOrderTemplate'
 
-import CollectionFilterMapViewContainer from '../containers/CollectionFilterMapViewContainer';
-import FooterContainer from '../containers/FooterContainer';
-import HeaderContainer from '../containers/HeaderContainer';
-import ToolDrawerContainer from '../containers/ToolDrawerContainer';
-import CatalogCardContainer from '../containers/CatalogCardContainer';
-import TnrisDownloadTemplateContainer from '../containers/TnrisDownloadTemplateContainer';
-import OrderCartViewContainer from '../containers/OrderCartViewContainer';
-import NotFoundContainer from '../containers/NotFoundContainer';
+import CollectionFilterMapViewContainer from '../containers/CollectionFilterMapViewContainer'
+import FooterContainer from '../containers/FooterContainer'
+import HeaderContainer from '../containers/HeaderContainer'
+import ToolDrawerContainer from '../containers/ToolDrawerContainer'
+import CatalogCardContainer from '../containers/CatalogCardContainer'
+import TnrisDownloadTemplateContainer from '../containers/TnrisDownloadTemplateContainer'
+import OrderCartViewContainer from '../containers/OrderCartViewContainer'
+import NotFoundContainer from '../containers/NotFoundContainer'
 
 // import loadingImage from '../images/loading.gif';
-import noDataImage from '../images/no-data.png';
-import noDataImage666 from '../images/no-data-satan.png';
+import noDataImage from '../images/no-data.png'
+import noDataImage666 from '../images/no-data-satan.png'
 
 // global sass breakpoint variables to be used in js
-import breakpoints from '../sass/_breakpoints.scss';
+import breakpoints from '../sass/_breakpoints.scss'
 
 export default class Catalog extends React.Component {
   constructor(props) {

--- a/src/components/CatalogCard.jsx
+++ b/src/components/CatalogCard.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from 'react'
 
 export default class CatalogCard extends React.Component {
   constructor(props) {

--- a/src/components/CollectionFilter.jsx
+++ b/src/components/CollectionFilter.jsx
@@ -1,6 +1,6 @@
-import React from 'react';
-import { matchPath } from 'react-router-dom';
-import turfExtent from 'turf-extent';
+import React from 'react'
+import { matchPath } from 'react-router-dom'
+import turfExtent from 'turf-extent'
 // the carto core api is a CDN in the app template HTML (not available as NPM package)
 // so we create a constant to represent it so it's available to the component
 const cartodb = window.cartodb;

--- a/src/components/CollectionFilterMap.jsx
+++ b/src/components/CollectionFilterMap.jsx
@@ -1,15 +1,15 @@
-import React from 'react';
-import CollectionFilterMapInstructions from './CollectionFilterMapInstructions';
+import React from 'react'
+import CollectionFilterMapInstructions from './CollectionFilterMapInstructions'
 
-import mapboxgl from 'mapbox-gl';
-import MapboxDraw from '@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.js';
-import '@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.css';
-import DrawRectangle from 'mapbox-gl-draw-rectangle-mode';
-import turfExtent from 'turf-extent';
-import styles from '../sass/index.scss';
+import mapboxgl from 'mapbox-gl'
+import MapboxDraw from '@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.js'
+import '@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.css'
+import DrawRectangle from 'mapbox-gl-draw-rectangle-mode'
+import turfExtent from 'turf-extent'
+import styles from '../sass/index.scss'
 
 // global sass breakpoint variables to be used in js
-import breakpoints from '../sass/_breakpoints.scss';
+import breakpoints from '../sass/_breakpoints.scss'
 
 // the carto core api is a CDN in the app template HTML (not available as NPM package)
 // so we create a constant to represent it so it's available to the component

--- a/src/components/CollectionFilterMapInstructions.jsx
+++ b/src/components/CollectionFilterMapInstructions.jsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React from 'react'
 
 // global sass breakpoint variables to be used in js
-import breakpoints from '../sass/_breakpoints.scss';
+import breakpoints from '../sass/_breakpoints.scss'
 
 export default class CollectionFilterMapInstructions extends React.Component {
   constructor(props) {

--- a/src/components/CollectionFilterMapView.jsx
+++ b/src/components/CollectionFilterMapView.jsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React from 'react'
 
-import CollectionFilterMapContainer from '../containers/CollectionFilterMapContainer';
+import CollectionFilterMapContainer from '../containers/CollectionFilterMapContainer'
 
 export default class CollectionFilterMapView extends React.Component {
   constructor() {

--- a/src/components/CollectionSearcher.jsx
+++ b/src/components/CollectionSearcher.jsx
@@ -1,7 +1,7 @@
-import React from 'react';
-import Downshift from 'downshift';
-import { MDCTextField } from '@material/textfield';
-import { matchPath } from 'react-router-dom';
+import React from 'react'
+import Downshift from 'downshift'
+import { MDCTextField } from '@material/textfield'
+import { matchPath } from 'react-router-dom'
 
 export default class CollectionSearcher extends React.Component {
 

--- a/src/components/CollectionSorter.jsx
+++ b/src/components/CollectionSorter.jsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { matchPath } from 'react-router-dom';
+import React from 'react'
+import { matchPath } from 'react-router-dom'
 
 class CollectionSorter extends React.Component {
 

--- a/src/components/CollectionTimeslider.jsx
+++ b/src/components/CollectionTimeslider.jsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import { matchPath } from 'react-router-dom';
-import Range from 'rc-slider/lib/Range';
+import React from 'react'
+import { matchPath } from 'react-router-dom'
+import Range from 'rc-slider/lib/Range'
 
-import 'rc-slider/assets/index.css';
+import 'rc-slider/assets/index.css'
 
 export default class CollectionTimeslider extends React.Component {
   constructor(props) {

--- a/src/components/ContactOutsideForm.jsx
+++ b/src/components/ContactOutsideForm.jsx
@@ -1,10 +1,10 @@
-import React, { Component } from 'react';
-import {MDCTextField} from '@material/textfield';
-import {MDCFloatingLabel} from '@material/floating-label';
-import {MDCLineRipple} from '@material/line-ripple';
-import {MDCRipple} from '@material/ripple';
-import {MDCSelect} from '@material/select';
-import ReCAPTCHA from "react-google-recaptcha";
+import React, { Component } from 'react'
+import {MDCTextField} from '@material/textfield'
+import {MDCFloatingLabel} from '@material/floating-label'
+import {MDCLineRipple} from '@material/line-ripple'
+import {MDCRipple} from '@material/ripple'
+import {MDCSelect} from '@material/select'
+import ReCAPTCHA from "react-google-recaptcha"
 
 class ContactOutsideForm extends Component {
 

--- a/src/components/ContactTnrisForm.jsx
+++ b/src/components/ContactTnrisForm.jsx
@@ -1,10 +1,10 @@
-import React, { Component } from 'react';
-import {MDCTextField} from '@material/textfield';
-import {MDCFloatingLabel} from '@material/floating-label';
-import {MDCLineRipple} from '@material/line-ripple';
-import {MDCRipple} from '@material/ripple';
-import {MDCSelect} from '@material/select';
-import ReCAPTCHA from "react-google-recaptcha";
+import React, { Component } from 'react'
+import {MDCTextField} from '@material/textfield'
+import {MDCFloatingLabel} from '@material/floating-label'
+import {MDCLineRipple} from '@material/line-ripple'
+import {MDCRipple} from '@material/ripple'
+import {MDCSelect} from '@material/select'
+import ReCAPTCHA from "react-google-recaptcha"
 
 class ContactTnrisForm extends Component {
 

--- a/src/components/DialogTemplateListItems/CountyCoverage.jsx
+++ b/src/components/DialogTemplateListItems/CountyCoverage.jsx
@@ -142,11 +142,37 @@ export default class CountyCoverage extends React.Component {
 
   render() {
     window.scrollTo(0,0);
+
+    let noticeClass = 'mdc-typography--body1 show-notice'
+    // const notice = document.getElementById('county-coverage-notice')
+    const coverageNotice = (
+      `<div id='county-coverage-notice' className=${noticeClass}>
+        Imagery may have incomplete coverage for a particular county and may be of varying quality.
+      </div>`)
+
+    coverageNotice.classList.contains('show-notice') ?
+      console.log('show-notice class') : console.log('hide class');
+
+    // if (coverageNotice.classList.contains('hide')) {
+    //   coverageNotice.classList.remove('hide');
+    //   setTimeout(function () {
+    //     coverageNotice.classList.remove('visual-hide');
+    //   }, 5);
+    // } else {
+    //   coverageNotice.classList.add('visual-hide');
+    //   coverageNotice.addEventListener('transitionend', function(e) {
+    //     coverageNotice.classList.add('hide');
+    //   }, {
+    //     capture: false,
+    //     once: true,
+    //     passive: false
+    //   });
+    // }
+
     return (
+
       <div className="county-coverage-component">
-        <div id='county-coverage-notice' className='mdc-typography--body1'>
-          Imagery may have incomplete coverage for a particular county and may be of varying quality.
-        </div>
+        {coverageNotice}
         <div id='county-coverage-map'></div>
       </div>
     )

--- a/src/components/DialogTemplateListItems/CountyCoverage.jsx
+++ b/src/components/DialogTemplateListItems/CountyCoverage.jsx
@@ -144,14 +144,19 @@ export default class CountyCoverage extends React.Component {
     window.scrollTo(0,0);
 
     setTimeout(function() {
-      document.getElementById('county-coverage-notice').style.display = "none";
-    }, 6000);
+      const notice = document.getElementById('county-coverage-notice');
+      if (notice) {
+        notice.style.display = "none";
+      }
+    }, 10000);
 
     return (
 
       <div className="county-coverage-component">
         <div id='county-coverage-notice' className='mdc-typography--body1 display'>
-          Imagery may have incomplete coverage for a particular county and may be of varying quality.
+          <strong>Note: </strong>This is a map showing the general coverage area for this dataset. You
+          cannot download the data from here. Imagery may have incomplete coverage for a particular county
+          and may be of varying quality.
         </div>
         <div id='county-coverage-map'></div>
       </div>

--- a/src/components/DialogTemplateListItems/CountyCoverage.jsx
+++ b/src/components/DialogTemplateListItems/CountyCoverage.jsx
@@ -9,11 +9,6 @@ const cartodb = window.cartodb;
 export default class CountyCoverage extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {
-      noteInstruct: true
-    };
-
-    this.toggleInstructions = this.toggleInstructions.bind(this);
     // bind our map builder functions
     this.createMap = this.createMap.bind(this);
   }
@@ -24,12 +19,6 @@ export default class CountyCoverage extends React.Component {
 
   componentWillUnmount() {
     this.map.remove();
-  }
-
-  toggleInstructions () {
-    this.setState({
-      noteInstruct: !this.state.noteInstruct
-    });
   }
 
   createMap() {
@@ -153,7 +142,6 @@ export default class CountyCoverage extends React.Component {
   }
 
   render() {
-    window.scrollTo(0,0);
 
     return (
 

--- a/src/components/DialogTemplateListItems/CountyCoverage.jsx
+++ b/src/components/DialogTemplateListItems/CountyCoverage.jsx
@@ -155,8 +155,8 @@ export default class CountyCoverage extends React.Component {
       <div className="county-coverage-component">
         <div id='county-coverage-notice' className='mdc-typography--body1 display'>
           <strong>Note: </strong>This is a map showing the general coverage area for this dataset. You
-          cannot download the data from here. Imagery may have incomplete coverage for a particular county
-          and may be of varying quality.
+          cannot download the data from here, but you can order the data by clicking the order tab. Imagery
+          may have incomplete coverage for a particular county and may be of varying quality.
         </div>
         <div id='county-coverage-map'></div>
       </div>

--- a/src/components/DialogTemplateListItems/CountyCoverage.jsx
+++ b/src/components/DialogTemplateListItems/CountyCoverage.jsx
@@ -1,6 +1,7 @@
-import React from 'react';
-import mapboxgl from 'mapbox-gl';
-import styles from '../../sass/index.scss';
+import React from 'react'
+import mapboxgl from 'mapbox-gl'
+import styles from '../../sass/index.scss'
+import CountyCoverageNote from './CountyCoverageNote'
 // the carto core api is a CDN in the app template HTML (not available as NPM package)
 // so we create a constant to represent it so it's available to the component
 const cartodb = window.cartodb;
@@ -8,6 +9,11 @@ const cartodb = window.cartodb;
 export default class CountyCoverage extends React.Component {
   constructor(props) {
     super(props);
+    this.state = {
+      noteInstruct: true
+    };
+
+    this.toggleInstructions = this.toggleInstructions.bind(this);
     // bind our map builder functions
     this.createMap = this.createMap.bind(this);
   }
@@ -18,6 +24,12 @@ export default class CountyCoverage extends React.Component {
 
   componentWillUnmount() {
     this.map.remove();
+  }
+
+  toggleInstructions () {
+    this.setState({
+      noteInstruct: !this.state.noteInstruct
+    });
   }
 
   createMap() {
@@ -143,22 +155,14 @@ export default class CountyCoverage extends React.Component {
   render() {
     window.scrollTo(0,0);
 
-    setTimeout(function() {
-      const notice = document.getElementById('county-coverage-notice');
-      if (notice) {
-        notice.style.display = "none";
-      }
-    }, 10000);
-
     return (
 
-      <div className="county-coverage-component">
-        <div id='county-coverage-notice' className='mdc-typography--body1 display'>
-          <strong>Note: </strong>This is a map showing the general coverage area for this dataset. You
-          cannot download the data from here, but you can order the data by clicking the order tab. Imagery
-          may have incomplete coverage for a particular county and may be of varying quality.
+      <div className="template-content-div county-coverage-component">
+        <div className='mdc-typography--headline5 template-content-div-header'>
+          Coverage Area
         </div>
         <div id='county-coverage-map'></div>
+        <CountyCoverageNote />
       </div>
     )
   }

--- a/src/components/DialogTemplateListItems/CountyCoverage.jsx
+++ b/src/components/DialogTemplateListItems/CountyCoverage.jsx
@@ -143,36 +143,16 @@ export default class CountyCoverage extends React.Component {
   render() {
     window.scrollTo(0,0);
 
-    // let noticeClass = 'mdc-typography--body1 show-notice'
-    // const notice = document.getElementById('county-coverage-notice')
-    const coverageNotice = (
-      <div id='county-coverage-notice' className='mdc-typography--body1'>
-        Imagery may have incomplete coverage for a particular county and may be of varying quality.
-      </div>)
-
-    // coverageNotice.classList.contains('show-notice') ?
-    //   console.log('show-notice class') : console.log('hide class');
-
-    // if (coverageNotice.classList.contains('hide')) {
-    //   coverageNotice.classList.remove('hide');
-    //   setTimeout(function () {
-    //     coverageNotice.classList.remove('visual-hide');
-    //   }, 5);
-    // } else {
-    //   coverageNotice.classList.add('visual-hide');
-    //   coverageNotice.addEventListener('transitionend', function(e) {
-    //     coverageNotice.classList.add('hide');
-    //   }, {
-    //     capture: false,
-    //     once: true,
-    //     passive: false
-    //   });
-    // }
+    setTimeout(function() {
+      document.getElementById('county-coverage-notice').style.display = "none";
+    }, 6000);
 
     return (
 
       <div className="county-coverage-component">
-        {coverageNotice}
+        <div id='county-coverage-notice' className='mdc-typography--body1 display'>
+          Imagery may have incomplete coverage for a particular county and may be of varying quality.
+        </div>
         <div id='county-coverage-map'></div>
       </div>
     )

--- a/src/components/DialogTemplateListItems/CountyCoverage.jsx
+++ b/src/components/DialogTemplateListItems/CountyCoverage.jsx
@@ -143,15 +143,15 @@ export default class CountyCoverage extends React.Component {
   render() {
     window.scrollTo(0,0);
 
-    let noticeClass = 'mdc-typography--body1 show-notice'
+    // let noticeClass = 'mdc-typography--body1 show-notice'
     // const notice = document.getElementById('county-coverage-notice')
     const coverageNotice = (
-      `<div id='county-coverage-notice' className=${noticeClass}>
+      <div id='county-coverage-notice' className='mdc-typography--body1'>
         Imagery may have incomplete coverage for a particular county and may be of varying quality.
-      </div>`)
+      </div>)
 
-    coverageNotice.classList.contains('show-notice') ?
-      console.log('show-notice class') : console.log('hide class');
+    // coverageNotice.classList.contains('show-notice') ?
+    //   console.log('show-notice class') : console.log('hide class');
 
     // if (coverageNotice.classList.contains('hide')) {
     //   coverageNotice.classList.remove('hide');

--- a/src/components/DialogTemplateListItems/CountyCoverageNote.jsx
+++ b/src/components/DialogTemplateListItems/CountyCoverageNote.jsx
@@ -1,11 +1,10 @@
 import React from 'react';
 
-export default class TnrisDownloadMapNote extends React.Component {
+export default class CountyCoverageNote extends React.Component {
   constructor(props) {
       super(props);
 
       this.state = {
-        noteHover: false,
         noteInstruct: true
       };
 
@@ -18,7 +17,7 @@ export default class TnrisDownloadMapNote extends React.Component {
       this.setState({
         noteInstruct: false
       })
-    }, 8000);
+    }, 10000);
   }
 
   componentWillUnmount () {
@@ -35,21 +34,14 @@ export default class TnrisDownloadMapNote extends React.Component {
   }
 
   render() {
-    const noteContent = this.state.noteHover ? (
-      <p>
-        Every dataset (excluding External Link availability) is available for order directly from TNRIS. Click the Order tab if the quantity of data needed is too large to download.
-      {/*<br />
-        Every downloadable dataset is publically available via an AWS S3 bucket and can be accessed using the AWS CLI for bulk and programmatic downloads. Click the Contact tab to inquire with TNRIS about details related to S3 bulk access.*/}
-      </p>
-    ) : (
-      <i className="material-icons">toys</i>
-    );
 
     const noteInstruct = this.state.noteInstruct ? (
       <div>
         <i className="material-icons close-icon" title="Minimize Information" onClick={() => {this.toggleInstructions()}}>close</i>
-        <p title="Download Information">
-          Click a polygon in the map to view available downloads and information.
+        <p title="Coverage Information">
+          <strong>Note: </strong>This is a map showing the general coverage area for this dataset. You
+          cannot download the data from here, but you can order the data by clicking the order tab. Imagery
+          may have incomplete coverage for a particular county and may be of varying quality.
         </p>
       </div>
     ) : (
@@ -58,16 +50,9 @@ export default class TnrisDownloadMapNote extends React.Component {
 
     return (
       <div>
-        <div id='tnris-download-instructions'
+        <div id='county-coverage-notice'
           className='mdc-typography--caption'>
           {noteInstruct}
-        </div>
-
-        <div id='tnris-download-note'
-          className='mdc-typography--caption'
-          onMouseEnter={() => {this.setState({noteHover:true})}}
-          onMouseLeave={() => {this.setState({noteHover:false})}}>
-          {noteContent}
         </div>
       </div>
     );

--- a/src/components/DialogTemplateListItems/CountyCoverageNote.jsx
+++ b/src/components/DialogTemplateListItems/CountyCoverageNote.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from 'react'
 
 export default class CountyCoverageNote extends React.Component {
   constructor(props) {

--- a/src/components/DialogTemplateListItems/Description.jsx
+++ b/src/components/DialogTemplateListItems/Description.jsx
@@ -1,5 +1,4 @@
-import React from 'react';
-
+import React from 'react'
 
 export default class Description extends React.Component {
 

--- a/src/components/DialogTemplateListItems/HistoricalProducts.jsx
+++ b/src/components/DialogTemplateListItems/HistoricalProducts.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from 'react'
 
 export default class HistoricalProducts extends React.Component {
   render() {

--- a/src/components/DialogTemplateListItems/LidarBlurb.jsx
+++ b/src/components/DialogTemplateListItems/LidarBlurb.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from 'react'
 
 export default class LidarBlurb extends React.Component {
 

--- a/src/components/DialogTemplateListItems/Ls4Links.jsx
+++ b/src/components/DialogTemplateListItems/Ls4Links.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from 'react'
 
 export default class Ls4Links extends React.Component {
   constructor (props) {

--- a/src/components/DialogTemplateListItems/Metadata.jsx
+++ b/src/components/DialogTemplateListItems/Metadata.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from 'react'
 
 export default class Metadata extends React.Component {
   render() {

--- a/src/components/DialogTemplateListItems/Metadata.jsx
+++ b/src/components/DialogTemplateListItems/Metadata.jsx
@@ -244,6 +244,9 @@ export default class Metadata extends React.Component {
 
     return (
       <div className="template-content-div metadata">
+        <div className='mdc-typography--headline5 template-content-div-header'>
+          Metadata
+        </div>
         <ul className="mdc-list mdc-list--non-interactive">
           {partners}
           {source}

--- a/src/components/DialogTemplateListItems/OeServices.jsx
+++ b/src/components/DialogTemplateListItems/OeServices.jsx
@@ -1,5 +1,4 @@
-import React from 'react';
-
+import React from 'react'
 
 export default class OeServices extends React.Component {
 

--- a/src/components/DialogTemplateListItems/Services.jsx
+++ b/src/components/DialogTemplateListItems/Services.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from 'react'
 
 export default class Services extends React.Component {
   constructor (props) {

--- a/src/components/DialogTemplateListItems/ShareButtons.jsx
+++ b/src/components/DialogTemplateListItems/ShareButtons.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from 'react'
 import {
   EmailShareButton,
   EmailIcon,
@@ -8,7 +8,7 @@ import {
   RedditIcon,
   TwitterShareButton,
   TwitterIcon
-} from 'react-share';
+} from 'react-share'
 
 export default class ShareButtons extends React.Component {
   _isMounted = false;

--- a/src/components/DialogTemplateListItems/SourceCitation.jsx
+++ b/src/components/DialogTemplateListItems/SourceCitation.jsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React from 'react'
 
 // global sass breakpoint variables to be used in js
-import breakpoints from '../../sass/_breakpoints.scss';
+import breakpoints from '../../sass/_breakpoints.scss'
 
 export default class SourceCitation extends React.Component {
   constructor(props) {

--- a/src/components/DialogTemplateListItems/Supplementals.jsx
+++ b/src/components/DialogTemplateListItems/Supplementals.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from 'react'
 
 export default class Supplementals extends React.Component {
 

--- a/src/components/Drawer.jsx
+++ b/src/components/Drawer.jsx
@@ -1,7 +1,7 @@
-import React from 'react';
-import {MDCDrawer} from "@material/drawer";
-import tnrisLogo from '../images/tnris_globe.png';
-import twdbLogo from '../images/twdb_splash_icon.png';
+import React from 'react'
+import {MDCDrawer} from "@material/drawer"
+import tnrisLogo from '../images/tnris_globe.png'
+import twdbLogo from '../images/twdb_splash_icon.png'
 
 export default class Drawer extends React.Component {
 

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { MDCMenu } from '@material/menu';
+import React from 'react'
+import { MDCMenu } from '@material/menu'
 
 export default class Footer extends React.Component {
   constructor(props) {

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,7 +1,7 @@
-import React from 'react';
-import {MDCTopAppBar} from '@material/top-app-bar/index';
-import NotificationBadge from 'react-notification-badge';
-import {Effect} from 'react-notification-badge';
+import React from 'react'
+import {MDCTopAppBar} from '@material/top-app-bar/index'
+import NotificationBadge from 'react-notification-badge'
+import {Effect} from 'react-notification-badge'
 
 // global sass breakpoint variables to be used in js
 import breakpoints from '../sass/_breakpoints.scss';

--- a/src/components/HistoricalAerialTemplate/HistoricalAerialTemplate.jsx
+++ b/src/components/HistoricalAerialTemplate/HistoricalAerialTemplate.jsx
@@ -1,12 +1,15 @@
-import React from 'react';
-import {MDCTopAppBar} from '@material/top-app-bar/index';
-import {MDCTabBar} from '@material/tab-bar';
-import { MDCMenu } from '@material/menu';
+import React from 'react'
+import {MDCTopAppBar} from '@material/top-app-bar/index'
+import {MDCTabBar} from '@material/tab-bar'
+import { MDCMenu } from '@material/menu'
 
-import HistoricalAerialTemplateDetails from './HistoricalAerialTemplateDetails';
-import CountyCoverageContainer from '../../containers/CountyCoverageContainer'
-import OrderTnrisDataFormContainer from '../../containers/OrderTnrisDataFormContainer';
-import ContactContainer from '../../containers/ContactContainer';
+import HistoricalAerialTemplateDetails from './HistoricalAerialTemplateDetails'
+
+import Images from '../Images'
+
+// import CountyCoverageContainer from '../../containers/CountyCoverageContainer'
+import OrderTnrisDataFormContainer from '../../containers/OrderTnrisDataFormContainer'
+import ContactContainer from '../../containers/ContactContainer'
 
 export default class HistoricalAerialTemplate extends React.Component {
   constructor(props) {
@@ -32,7 +35,7 @@ export default class HistoricalAerialTemplate extends React.Component {
       case 'details':
         tabIndex = 0;
         break;
-      case 'coverage':
+      case 'images':
         tabIndex = 1;
         break;
       case 'order':
@@ -59,8 +62,15 @@ export default class HistoricalAerialTemplate extends React.Component {
       case 'details':
         showComponent = <HistoricalAerialTemplateDetails collection={this.props.collection} />;
         break;
-      case 'coverage':
-        showComponent = <CountyCoverageContainer counties={this.props.collection.counties} />;
+      // case 'coverage':
+      //   showComponent = <CountyCoverageContainer counties={this.props.collection.counties} />;
+      //   break;
+      case 'images':
+        showComponent = (
+          <Images
+            thumbnail={this.props.collection.thumbnail_image}
+            images={this.props.collection.images} />
+        )
         break;
       case 'order':
         showComponent = (
@@ -124,24 +134,21 @@ export default class HistoricalAerialTemplate extends React.Component {
                         <span className="mdc-tab__ripple"></span>
                       </button>
 
-                      { this.props.collection.counties ? (
-                          <button
-                            className="mdc-tab"
-                            role="tab"
-                            aria-selected="false"
-                            tabIndex="-1"
-                            onClick={() => this.setTemplateView("coverage")}
-                            title="Coverage Map">
-                            <span className="mdc-tab__content">coverage</span>
-                            <span className="mdc-tab-indicator">
-                              <span
-                                className="mdc-tab-indicator__content mdc-tab-indicator__content--underline">
-                              </span>
-                            </span>
-                            <span className="mdc-tab__ripple"></span>
-                          </button>
-                        ) : ""
-                      }
+                      <button
+                        className="mdc-tab"
+                        role="tab"
+                        aria-selected="false"
+                        tabIndex="-1"
+                        onClick={() => this.setTemplateView("images")}
+                        title="Preview Images">
+                        <span className="mdc-tab__content">images</span>
+                        <span className="mdc-tab-indicator">
+                          <span
+                            className="mdc-tab-indicator__content mdc-tab-indicator__content--underline">
+                          </span>
+                        </span>
+                        <span className="mdc-tab__ripple"></span>
+                      </button>
 
                       <button
                         className="mdc-tab"
@@ -159,7 +166,6 @@ export default class HistoricalAerialTemplate extends React.Component {
 
                       <button className="mdc-tab" role="tab" aria-selected="false" tabIndex="-1"  onClick={() => this.setTemplateView("contact")} title="Contact">
                         <span className="mdc-tab__content">contact
-                          {/*<span className="mdc-tab__icon material-icons">contact_support</span>*/}
                         </span>
                         <span className="mdc-tab-indicator">
                           <span className="mdc-tab-indicator__content mdc-tab-indicator__content--underline"></span>
@@ -183,26 +189,22 @@ export default class HistoricalAerialTemplate extends React.Component {
                       className={
                         this.state.view === 'details' ? 'mdc-list-item  mdc-list-item--activated' : 'mdc-list-item'
                       }
-                      onClick={() => this.setTemplateView("details")}>
-                      Details
+                      onClick={() => this.setTemplateView("details")}>Details
                     </div>
-                    { this.props.collection.counties ? (
-                      <div className={this.state.view === 'coverage' ? 'mdc-list-item  mdc-list-item--activated' : 'mdc-list-item'}
-                         onClick={() => this.setTemplateView("coverage")}>Coverage
-                         {/*<i className="mdc-tab__icon material-icons">details</i>*/}
-                      </div>
-                      ) : ""
-                    }
+                    <div
+                      className={
+                        this.state.view === 'images' ? 'mdc-list-item  mdc-list-item--activated' : 'mdc-list-item'
+                      }
+                      onClick={() => this.setTemplateView("images")}>Images
+                    </div>
                     <div
                       className={
                         this.state.view === 'order' ? 'mdc-list-item  mdc-list-item--activated' : 'mdc-list-item'
                       }
-                      onClick={() => this.setTemplateView("order")}>
-                      Order
+                      onClick={() => this.setTemplateView("order")}>Order
                     </div>
                     <div className={this.state.view === 'contact' ? 'mdc-list-item  mdc-list-item--activated' : 'mdc-list-item'}
                        onClick={() => this.setTemplateView("contact")}>Contact
-                       {/*<i className="mdc-tab__icon material-icons">contact_support</i>*/}
                     </div>
                   </nav>
                 </div>

--- a/src/components/HistoricalAerialTemplate/HistoricalAerialTemplate.jsx
+++ b/src/components/HistoricalAerialTemplate/HistoricalAerialTemplate.jsx
@@ -134,21 +134,24 @@ export default class HistoricalAerialTemplate extends React.Component {
                         <span className="mdc-tab__ripple"></span>
                       </button>
 
-                      <button
-                        className="mdc-tab"
-                        role="tab"
-                        aria-selected="false"
-                        tabIndex="-1"
-                        onClick={() => this.setTemplateView("images")}
-                        title="Preview Images">
-                        <span className="mdc-tab__content">images</span>
-                        <span className="mdc-tab-indicator">
-                          <span
-                            className="mdc-tab-indicator__content mdc-tab-indicator__content--underline">
+                      {this.props.collection.images ? (
+                        <button
+                          className="mdc-tab"
+                          role="tab"
+                          aria-selected="false"
+                          tabIndex="-1"
+                          onClick={() => this.setTemplateView("images")}
+                          title="Preview Images">
+                          <span className="mdc-tab__content">images</span>
+                          <span className="mdc-tab-indicator">
+                            <span
+                              className="mdc-tab-indicator__content mdc-tab-indicator__content--underline">
+                            </span>
                           </span>
-                        </span>
-                        <span className="mdc-tab__ripple"></span>
-                      </button>
+                          <span className="mdc-tab__ripple"></span>
+                        </button>
+                        ) : ""
+                      }
 
                       <button
                         className="mdc-tab"

--- a/src/components/HistoricalAerialTemplate/HistoricalAerialTemplate.jsx
+++ b/src/components/HistoricalAerialTemplate/HistoricalAerialTemplate.jsx
@@ -7,7 +7,6 @@ import HistoricalAerialTemplateDetails from './HistoricalAerialTemplateDetails'
 
 import Images from '../Images'
 
-// import CountyCoverageContainer from '../../containers/CountyCoverageContainer'
 import OrderTnrisDataFormContainer from '../../containers/OrderTnrisDataFormContainer'
 import ContactContainer from '../../containers/ContactContainer'
 

--- a/src/components/HistoricalAerialTemplate/HistoricalAerialTemplate.jsx
+++ b/src/components/HistoricalAerialTemplate/HistoricalAerialTemplate.jsx
@@ -138,8 +138,8 @@ export default class HistoricalAerialTemplate extends React.Component {
                           aria-selected="false"
                           tabIndex="-1"
                           onClick={() => this.setTemplateView("images")}
-                          title="Images">
-                          <span className="mdc-tab__content">images</span>
+                          title="Preview">
+                          <span className="mdc-tab__content">preview</span>
                           <span className="mdc-tab-indicator">
                             <span
                               className="mdc-tab-indicator__content mdc-tab-indicator__content--underline">

--- a/src/components/HistoricalAerialTemplate/HistoricalAerialTemplate.jsx
+++ b/src/components/HistoricalAerialTemplate/HistoricalAerialTemplate.jsx
@@ -62,9 +62,6 @@ export default class HistoricalAerialTemplate extends React.Component {
       case 'details':
         showComponent = <HistoricalAerialTemplateDetails collection={this.props.collection} />;
         break;
-      // case 'coverage':
-      //   showComponent = <CountyCoverageContainer counties={this.props.collection.counties} />;
-      //   break;
       case 'images':
         showComponent = (
           <Images
@@ -141,7 +138,7 @@ export default class HistoricalAerialTemplate extends React.Component {
                           aria-selected="false"
                           tabIndex="-1"
                           onClick={() => this.setTemplateView("images")}
-                          title="Preview Images">
+                          title="Images">
                           <span className="mdc-tab__content">images</span>
                           <span className="mdc-tab-indicator">
                             <span

--- a/src/components/HistoricalAerialTemplate/HistoricalAerialTemplateDetails.jsx
+++ b/src/components/HistoricalAerialTemplate/HistoricalAerialTemplateDetails.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from 'react'
 
 import Description from '../DialogTemplateListItems/Description'
 import SourceCitation from '../DialogTemplateListItems/SourceCitation'
@@ -6,11 +6,10 @@ import Metadata from '../DialogTemplateListItems/Metadata'
 import HistoricalProducts from '../DialogTemplateListItems/HistoricalProducts'
 import Ls4Links from '../DialogTemplateListItems/Ls4Links'
 import ShareButtons from '../DialogTemplateListItems/ShareButtons'
-// import Images from '../DialogTemplateListItems/Images'
 import CountyCoverageContainer from '../../containers/CountyCoverageContainer'
 
 // global sass breakpoint variables to be used in js
-import breakpoints from '../../sass/_breakpoints.scss';
+import breakpoints from '../../sass/_breakpoints.scss'
 
 export default class TnrisDownloadTemplateDetails extends React.Component {
   constructor(props) {

--- a/src/components/HistoricalAerialTemplate/HistoricalAerialTemplateDetails.jsx
+++ b/src/components/HistoricalAerialTemplate/HistoricalAerialTemplateDetails.jsx
@@ -44,17 +44,10 @@ export default class TnrisDownloadTemplateDetails extends React.Component {
   }
 
   render() {
-    // const imageCarousel = this.props.collection.images ? (
-    //                       <Images
-    //                         thumbnail={this.props.collection.thumbnail_image}
-    //                         images={this.props.collection.images} />)
-    //                     : (
-    //                       <Images
-    //                         thumbnail={this.props.collection.thumbnail_image}
-    //                         images={this.props.collection.thumbnail_image} />
-    //                     );
 
-    const countyCoverage = <CountyCoverageContainer counties={this.props.collection.counties} />
+    const countyCoverage = this.props.collection.counties ? (
+                              <CountyCoverageContainer counties={this.props.collection.counties} />
+                            ) : "";
 
     const productsCard = this.props.collection.products ? (
                           <HistoricalProducts products={this.props.collection.products} />)

--- a/src/components/HistoricalAerialTemplate/HistoricalAerialTemplateDetails.jsx
+++ b/src/components/HistoricalAerialTemplate/HistoricalAerialTemplateDetails.jsx
@@ -6,7 +6,8 @@ import Metadata from '../DialogTemplateListItems/Metadata'
 import HistoricalProducts from '../DialogTemplateListItems/HistoricalProducts'
 import Ls4Links from '../DialogTemplateListItems/Ls4Links'
 import ShareButtons from '../DialogTemplateListItems/ShareButtons'
-import Images from '../DialogTemplateListItems/Images'
+// import Images from '../DialogTemplateListItems/Images'
+import CountyCoverageContainer from '../../containers/CountyCoverageContainer'
 
 // global sass breakpoint variables to be used in js
 import breakpoints from '../../sass/_breakpoints.scss';
@@ -43,15 +44,17 @@ export default class TnrisDownloadTemplateDetails extends React.Component {
   }
 
   render() {
-    const imageCarousel = this.props.collection.images ? (
-                          <Images
-                            thumbnail={this.props.collection.thumbnail_image}
-                            images={this.props.collection.images} />)
-                        : (
-                          <Images
-                            thumbnail={this.props.collection.thumbnail_image}
-                            images={this.props.collection.thumbnail_image} />
-                        );
+    // const imageCarousel = this.props.collection.images ? (
+    //                       <Images
+    //                         thumbnail={this.props.collection.thumbnail_image}
+    //                         images={this.props.collection.images} />)
+    //                     : (
+    //                       <Images
+    //                         thumbnail={this.props.collection.thumbnail_image}
+    //                         images={this.props.collection.thumbnail_image} />
+    //                     );
+
+    const countyCoverage = <CountyCoverageContainer counties={this.props.collection.counties} />
 
     const productsCard = this.props.collection.products ? (
                           <HistoricalProducts products={this.props.collection.products} />)
@@ -103,7 +106,8 @@ export default class TnrisDownloadTemplateDetails extends React.Component {
                                <ShareButtons />
                              </div>
                              <div className='mdc-layout-grid__cell mdc-layout-grid__cell--span-8'>
-                               {imageCarousel}
+                               {/*{imageCarousel}*/}
+                               {countyCoverage}
                                <div className="mdc-layout-grid__inner">
                                  <div className='mdc-layout-grid__cell mdc-layout-grid__cell--span-8'>
                                    <Description collection={collectionObj} />
@@ -116,7 +120,8 @@ export default class TnrisDownloadTemplateDetails extends React.Component {
                            </div>) : (
                            <div className="mdc-layout-grid__inner">
                              <div className='mdc-layout-grid__cell mdc-layout-grid__cell--span-12'>
-                               {imageCarousel}
+                               {/*{imageCarousel}*/}
+                               {countyCoverage}
                                <Metadata collection={this.props.collection} />
                                <Description collection={collectionObj} />
                                {sourceCitation}

--- a/src/components/Images.jsx
+++ b/src/components/Images.jsx
@@ -9,9 +9,8 @@ export default class Images extends React.Component {
     carousel_images.unshift(this.props.thumbnail);
     const multiImage = carousel_images.length > 1 ? true : false;
     return (
-
-      <div className="template-content-div">
-        <div>
+      <div className="tnris-template-images">
+        <div className="image-container">
           <Carousel
             autoPlay={multiImage}
             infiniteLoop={multiImage}

--- a/src/components/Images.jsx
+++ b/src/components/Images.jsx
@@ -5,9 +5,13 @@ import { Carousel } from 'react-responsive-carousel';
 export default class Images extends React.Component {
   render() {
     let carousel_images = this.props.images ? this.props.images.split(',') : "";
+
     carousel_images = carousel_images.filter(item => item !== this.props.thumbnail);
+
     carousel_images.unshift(this.props.thumbnail);
+
     const multiImage = carousel_images.length > 1 ? true : false;
+
     return (
       <div className="tnris-template-images">
         <div className="image-container">

--- a/src/components/Images.jsx
+++ b/src/components/Images.jsx
@@ -4,7 +4,7 @@ import { Carousel } from 'react-responsive-carousel';
 
 export default class Images extends React.Component {
   render() {
-    let carousel_images = this.props.images.split(',');
+    let carousel_images = this.props.images ? this.props.images.split(',') : "";
     carousel_images = carousel_images.filter(item => item !== this.props.thumbnail);
     carousel_images.unshift(this.props.thumbnail);
     const multiImage = carousel_images.length > 1 ? true : false;

--- a/src/components/Images.jsx
+++ b/src/components/Images.jsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React from 'react'
 
-import { Carousel } from 'react-responsive-carousel';
+import {Carousel} from 'react-responsive-carousel'
 
 export default class Images extends React.Component {
   render() {

--- a/src/components/NotFound.jsx
+++ b/src/components/NotFound.jsx
@@ -1,6 +1,6 @@
-import React, { Component } from 'react';
-import { Redirect } from 'react-router';
-import image404 from '../images/404.jpg';
+import React, { Component } from 'react'
+import { Redirect } from 'react-router'
+import image404 from '../images/404.jpg'
 
 class NotFound extends Component {
   componentDidMount() {

--- a/src/components/OrderCart.jsx
+++ b/src/components/OrderCart.jsx
@@ -1,10 +1,10 @@
-import React, { Component } from 'react';
-import {MDCTextField} from '@material/textfield';
-import {MDCFloatingLabel} from '@material/floating-label';
-import {MDCLineRipple} from '@material/line-ripple';
-import {MDCRipple} from '@material/ripple';
-import {MDCSelect} from '@material/select';
-import ReCAPTCHA from "react-google-recaptcha";
+import React, { Component } from 'react'
+import {MDCTextField} from '@material/textfield'
+import {MDCFloatingLabel} from '@material/floating-label'
+import {MDCLineRipple} from '@material/line-ripple'
+import {MDCRipple} from '@material/ripple'
+import {MDCSelect} from '@material/select'
+import ReCAPTCHA from "react-google-recaptcha"
 
 class OrderCart extends Component {
 

--- a/src/components/OrderCartView.jsx
+++ b/src/components/OrderCartView.jsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import OrderCartContainer from '../containers/OrderCartContainer';
+import React from 'react'
+import OrderCartContainer from '../containers/OrderCartContainer'
 
 class OrderCartView extends React.Component {
   constructor() {

--- a/src/components/OrderTnrisDataForm.jsx
+++ b/src/components/OrderTnrisDataForm.jsx
@@ -1,10 +1,10 @@
-import React, { Component } from 'react';
-import {MDCTextField} from '@material/textfield';
-import {MDCFloatingLabel} from '@material/floating-label';
-import {MDCLineRipple} from '@material/line-ripple';
-import {MDCRipple} from '@material/ripple';
-import {MDCSwitch} from '@material/switch';
-import {MDCTextFieldHelperText} from '@material/textfield/helper-text';
+import React, { Component } from 'react'
+import {MDCTextField} from '@material/textfield'
+import {MDCFloatingLabel} from '@material/floating-label'
+import {MDCLineRipple} from '@material/line-ripple'
+import {MDCRipple} from '@material/ripple'
+import {MDCSwitch} from '@material/switch'
+import {MDCTextFieldHelperText} from '@material/textfield/helper-text'
 
 class OrderTnrisDataForm extends Component {
 

--- a/src/components/ThemeChooser.jsx
+++ b/src/components/ThemeChooser.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component } from 'react'
 
 class ThemeChooser extends Component {
   constructor(props) {

--- a/src/components/TnrisDownloadTemplate/TnrisDownloadMapNote.jsx
+++ b/src/components/TnrisDownloadTemplate/TnrisDownloadMapNote.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from 'react'
 
 export default class TnrisDownloadMapNote extends React.Component {
   constructor(props) {

--- a/src/components/TnrisDownloadTemplate/TnrisDownloadMapNote.jsx
+++ b/src/components/TnrisDownloadTemplate/TnrisDownloadMapNote.jsx
@@ -3,19 +3,29 @@ import React from 'react';
 export default class TnrisDownloadMapNote extends React.Component {
   constructor(props) {
       super(props);
+
       this.state = {
         noteHover: false,
         noteInstruct: true
       };
+
       this.toggleInstructions = this.toggleInstructions.bind(this);
-      // this.update = this.update.bind(this);
   }
 
   componentDidMount () {
-    console.log('update function running')
-    this.change = setTimeout(() => {
-      this.setState({noteInstruct: false})
-    }, 3000)
+    // setTimeout to close noteInstruct after 8 secs
+    this.noteInstructTimer = setTimeout(() => {
+      this.setState({
+        noteInstruct: false
+      })
+    }, 8000);
+  }
+
+  componentWillUnmount () {
+    // clear setTimeout
+    if (this.noteInstructTimer) {
+      clearTimeout(this.noteInstructTimer);
+    }
   }
 
   toggleInstructions () {
@@ -45,8 +55,6 @@ export default class TnrisDownloadMapNote extends React.Component {
     ) : (
       <i className="material-icons" title="Download Instructions" onClick={() => {this.toggleInstructions()}}>info</i>
     );
-
-    // this.update();
 
     return (
       <div>

--- a/src/components/TnrisDownloadTemplate/TnrisDownloadMapNote.jsx
+++ b/src/components/TnrisDownloadTemplate/TnrisDownloadMapNote.jsx
@@ -49,7 +49,7 @@ export default class TnrisDownloadMapNote extends React.Component {
       <div>
         <i className="material-icons close-icon" title="Minimize Information" onClick={() => {this.toggleInstructions()}}>close</i>
         <p title="Download Information">
-          Click a polygon in the map to view available downloads and information.
+          Click a polygon in the map to download available data.
         </p>
       </div>
     ) : (

--- a/src/components/TnrisDownloadTemplate/TnrisDownloadMapNote.jsx
+++ b/src/components/TnrisDownloadTemplate/TnrisDownloadMapNote.jsx
@@ -8,6 +8,14 @@ export default class TnrisDownloadMapNote extends React.Component {
         noteInstruct: true
       };
       this.toggleInstructions = this.toggleInstructions.bind(this);
+      // this.update = this.update.bind(this);
+  }
+
+  componentDidMount () {
+    console.log('update function running')
+    this.change = setTimeout(() => {
+      this.setState({noteInstruct: false})
+    }, 3000)
   }
 
   toggleInstructions () {
@@ -37,6 +45,8 @@ export default class TnrisDownloadMapNote extends React.Component {
     ) : (
       <i className="material-icons" title="Download Instructions" onClick={() => {this.toggleInstructions()}}>info</i>
     );
+
+    // this.update();
 
     return (
       <div>

--- a/src/components/TnrisDownloadTemplate/TnrisDownloadTemplate.jsx
+++ b/src/components/TnrisDownloadTemplate/TnrisDownloadTemplate.jsx
@@ -1,13 +1,15 @@
-import React from 'react';
-import {MDCTopAppBar} from '@material/top-app-bar/index';
-import {MDCTabBar} from '@material/tab-bar';
-import { MDCMenu } from '@material/menu';
+import React from 'react'
+import {MDCTopAppBar} from '@material/top-app-bar/index'
+import {MDCTabBar} from '@material/tab-bar'
+import { MDCMenu } from '@material/menu'
 
-import TnrisDownloadTemplateDetails from './TnrisDownloadTemplateDetails';
+import TnrisDownloadTemplateDetails from './TnrisDownloadTemplateDetails'
 
-import TnrisDownloadTemplateDownloadContainer from '../../containers/TnrisDownloadTemplateDownloadContainer';
-import ContactContainer from '../../containers/ContactContainer';
-import OrderTnrisDataFormContainer from '../../containers/OrderTnrisDataFormContainer';
+import Images from '../Images'
+
+import TnrisDownloadTemplateDownloadContainer from '../../containers/TnrisDownloadTemplateDownloadContainer'
+import ContactContainer from '../../containers/ContactContainer'
+import OrderTnrisDataFormContainer from '../../containers/OrderTnrisDataFormContainer'
 
 export default class TnrisDownloadTemplate extends React.Component {
   constructor(props) {
@@ -44,7 +46,7 @@ export default class TnrisDownloadTemplate extends React.Component {
       case 'details':
         tabIndex = 0;
         break;
-      case 'download':
+      case 'images':
         tabIndex = 1;
         break;
       case 'order':
@@ -69,10 +71,14 @@ export default class TnrisDownloadTemplate extends React.Component {
 
     switch(this.state.view) {
       case 'details':
-        showComponent = <TnrisDownloadTemplateDetails collection={this.props.collection} />;
+        showComponent = <TnrisDownloadTemplateDetails collection={this.props.collection} />
         break;
-      case 'download':
-        showComponent = <TnrisDownloadTemplateDownloadContainer collectionName={this.props.collection.name}/>;
+      case 'images':
+        showComponent = (
+          <Images
+            thumbnail={this.props.collection.thumbnail_image}
+            images={this.props.collection.images} />
+        )
         break;
       case 'order':
         showComponent = (
@@ -141,9 +147,9 @@ export default class TnrisDownloadTemplate extends React.Component {
                         role="tab"
                         aria-selected="false"
                         tabIndex="-1"
-                        onClick={() => this.setTemplateView("download")}
+                        onClick={() => this.setTemplateView("images")}
                         title="Download">
-                        <span className="mdc-tab__content">download</span>
+                        <span className="mdc-tab__content">images</span>
                         <span className="mdc-tab-indicator">
                           <span
                             className="mdc-tab-indicator__content mdc-tab-indicator__content--underline">
@@ -202,8 +208,8 @@ export default class TnrisDownloadTemplate extends React.Component {
                       onClick={() => this.setTemplateView("details")}>Details
                       {/*<i className="mdc-tab__icon material-icons">details</i>*/}
                     </div>
-                    <div className={this.state.view === 'download' ? 'mdc-list-item  mdc-list-item--activated' : 'mdc-list-item'}
-                      onClick={() => this.setTemplateView("download")}>Download
+                    <div className={this.state.view === 'images' ? 'mdc-list-item  mdc-list-item--activated' : 'mdc-list-item'}
+                      onClick={() => this.setTemplateView("images")}>Images
                       {/*<i className="mdc-tab__icon material-icons">save_alt</i>*/}
                     </div>
                     <div className={this.state.view === 'order' ? 'mdc-list-item  mdc-list-item--activated' : 'mdc-list-item'}

--- a/src/components/TnrisDownloadTemplate/TnrisDownloadTemplate.jsx
+++ b/src/components/TnrisDownloadTemplate/TnrisDownloadTemplate.jsx
@@ -7,7 +7,6 @@ import TnrisDownloadTemplateDetails from './TnrisDownloadTemplateDetails'
 
 import Images from '../Images'
 
-// import TnrisDownloadTemplateDownloadContainer from '../../containers/TnrisDownloadTemplateDownloadContainer'
 import ContactContainer from '../../containers/ContactContainer'
 import OrderTnrisDataFormContainer from '../../containers/OrderTnrisDataFormContainer'
 

--- a/src/components/TnrisDownloadTemplate/TnrisDownloadTemplate.jsx
+++ b/src/components/TnrisDownloadTemplate/TnrisDownloadTemplate.jsx
@@ -149,8 +149,8 @@ export default class TnrisDownloadTemplate extends React.Component {
                           aria-selected="false"
                           tabIndex="-1"
                           onClick={() => this.setTemplateView("images")}
-                          title="Images">
-                          <span className="mdc-tab__content">images</span>
+                          title="Preview">
+                          <span className="mdc-tab__content">preview</span>
                           <span className="mdc-tab-indicator">
                             <span
                               className="mdc-tab-indicator__content mdc-tab-indicator__content--underline">

--- a/src/components/TnrisDownloadTemplate/TnrisDownloadTemplate.jsx
+++ b/src/components/TnrisDownloadTemplate/TnrisDownloadTemplate.jsx
@@ -7,7 +7,7 @@ import TnrisDownloadTemplateDetails from './TnrisDownloadTemplateDetails'
 
 import Images from '../Images'
 
-import TnrisDownloadTemplateDownloadContainer from '../../containers/TnrisDownloadTemplateDownloadContainer'
+// import TnrisDownloadTemplateDownloadContainer from '../../containers/TnrisDownloadTemplateDownloadContainer'
 import ContactContainer from '../../containers/ContactContainer'
 import OrderTnrisDataFormContainer from '../../containers/OrderTnrisDataFormContainer'
 

--- a/src/components/TnrisDownloadTemplate/TnrisDownloadTemplate.jsx
+++ b/src/components/TnrisDownloadTemplate/TnrisDownloadTemplate.jsx
@@ -149,7 +149,7 @@ export default class TnrisDownloadTemplate extends React.Component {
                           aria-selected="false"
                           tabIndex="-1"
                           onClick={() => this.setTemplateView("images")}
-                          title="Download">
+                          title="Images">
                           <span className="mdc-tab__content">images</span>
                           <span className="mdc-tab-indicator">
                             <span

--- a/src/components/TnrisDownloadTemplate/TnrisDownloadTemplate.jsx
+++ b/src/components/TnrisDownloadTemplate/TnrisDownloadTemplate.jsx
@@ -142,21 +142,24 @@ export default class TnrisDownloadTemplate extends React.Component {
                         <span className="mdc-tab__ripple"></span>
                       </button>
 
-                      <button
-                        className="mdc-tab"
-                        role="tab"
-                        aria-selected="false"
-                        tabIndex="-1"
-                        onClick={() => this.setTemplateView("images")}
-                        title="Download">
-                        <span className="mdc-tab__content">images</span>
-                        <span className="mdc-tab-indicator">
-                          <span
-                            className="mdc-tab-indicator__content mdc-tab-indicator__content--underline">
+                      { this.props.collection.images ? (
+                        <button
+                          className="mdc-tab"
+                          role="tab"
+                          aria-selected="false"
+                          tabIndex="-1"
+                          onClick={() => this.setTemplateView("images")}
+                          title="Download">
+                          <span className="mdc-tab__content">images</span>
+                          <span className="mdc-tab-indicator">
+                            <span
+                              className="mdc-tab-indicator__content mdc-tab-indicator__content--underline">
+                            </span>
                           </span>
-                        </span>
-                        <span className="mdc-tab__ripple"></span>
-                      </button>
+                          <span className="mdc-tab__ripple"></span>
+                        </button>
+                        ) : ""
+                      }
 
                       <button
                         className="mdc-tab"

--- a/src/components/TnrisDownloadTemplate/TnrisDownloadTemplateDetails.jsx
+++ b/src/components/TnrisDownloadTemplate/TnrisDownloadTemplateDetails.jsx
@@ -52,9 +52,10 @@ export default class TnrisDownloadTemplateDetails extends React.Component {
     //                       collection_name={this.props.collection.name} />)
     //                     : "";
 
-    const downloadMap = this.props.collection.template === 'tnris-download' ? (
-                      <TnrisDownloadTemplateDownload collection={this.props.collection} />)
-                     : "";
+    // const downloadMap = this.props.collection.template === 'tnris-download' ? (
+    //                   <TnrisDownloadTemplateDownload collection={this.props.collection} />)
+    //                  : "";
+    const downloadMap = "";
 
     console.log(this.props.collection);
 

--- a/src/components/TnrisDownloadTemplate/TnrisDownloadTemplateDetails.jsx
+++ b/src/components/TnrisDownloadTemplate/TnrisDownloadTemplateDetails.jsx
@@ -56,8 +56,6 @@ export default class TnrisDownloadTemplateDetails extends React.Component {
                           <TnrisDownloadTemplateDownloadContainer collectionName={this.props.collection.name} />
                         ) : "";
 
-    console.log(this.props.collection);
-
     const lidarCard = this.props.collection.category.includes('Lidar') ? (
                         <LidarBlurb />)
                         : "";

--- a/src/components/TnrisDownloadTemplate/TnrisDownloadTemplateDetails.jsx
+++ b/src/components/TnrisDownloadTemplate/TnrisDownloadTemplateDetails.jsx
@@ -18,10 +18,10 @@ export default class TnrisDownloadTemplateDetails extends React.Component {
     super(props)
 
     window.innerWidth >= parseInt(breakpoints.desktop, 10) ? this.state = {
-      gridLayout:'desktop'
-    } : this.state = {
-      gridLayout:'mobile'
-    };
+        gridLayout:'desktop'
+      } : this.state = {
+        gridLayout:'mobile'
+      };
 
     this.handleResize = this.handleResize.bind(this);
   }
@@ -45,12 +45,6 @@ export default class TnrisDownloadTemplateDetails extends React.Component {
   }
 
   render() {
-    // const imageCarousel = this.props.collection.images ? (
-    //                     <Images
-    //                       thumbnail={this.props.collection.thumbnail_image}
-    //                       images={this.props.collection.images}
-    //                       collection_name={this.props.collection.name} />)
-    //                     : "";
 
     const downloadMap = this.props.collection.template === 'tnris-download' ? (
                           <TnrisDownloadTemplateDownloadContainer collectionName={this.props.collection.name} />
@@ -90,7 +84,6 @@ export default class TnrisDownloadTemplateDetails extends React.Component {
                             <ShareButtons />
                           </div>
                           <div className='mdc-layout-grid__cell mdc-layout-grid__cell--span-8'>
-                            {/*{imageCarousel}*/}
                             {downloadMap}
                             <div className="mdc-layout-grid__inner">
                               <div className='mdc-layout-grid__cell mdc-layout-grid__cell--span-8'>
@@ -104,7 +97,6 @@ export default class TnrisDownloadTemplateDetails extends React.Component {
                         </div>) : (
                         <div className="mdc-layout-grid__inner">
                           <div className='mdc-layout-grid__cell mdc-layout-grid__cell--span-12'>
-                            {/*{imageCarousel}*/}
                             {downloadMap}
                             <Metadata collection={this.props.collection} />
                             {description}

--- a/src/components/TnrisDownloadTemplate/TnrisDownloadTemplateDetails.jsx
+++ b/src/components/TnrisDownloadTemplate/TnrisDownloadTemplateDetails.jsx
@@ -8,8 +8,6 @@ import Services from '../DialogTemplateListItems/Services'
 import Supplementals from '../DialogTemplateListItems/Supplementals'
 import ShareButtons from '../DialogTemplateListItems/ShareButtons'
 
-// import TnrisDownloadTemplateContainer from '../../containers/TnrisDownloadTemplateContainer'
-import TnrisDownloadTemplateDownload from './TnrisDownloadTemplateDownload'
 import TnrisDownloadTemplateDownloadContainer from '../../containers/TnrisDownloadTemplateDownloadContainer'
 
 // global sass breakpoint variables to be used in js
@@ -55,12 +53,8 @@ export default class TnrisDownloadTemplateDetails extends React.Component {
     //                     : "";
 
     const downloadMap = this.props.collection.template === 'tnris-download' ? (
-                          <TnrisDownloadTemplateDownloadContainer
-                            collectionName={this.props.collection.name}
-                             />
-    ) : "";
-
-    console.log(downloadMap);
+                          <TnrisDownloadTemplateDownloadContainer collectionName={this.props.collection.name} />
+                        ) : "";
 
     console.log(this.props.collection);
 

--- a/src/components/TnrisDownloadTemplate/TnrisDownloadTemplateDetails.jsx
+++ b/src/components/TnrisDownloadTemplate/TnrisDownloadTemplateDetails.jsx
@@ -7,8 +7,9 @@ import Metadata from '../DialogTemplateListItems/Metadata'
 import Services from '../DialogTemplateListItems/Services'
 import Supplementals from '../DialogTemplateListItems/Supplementals'
 import ShareButtons from '../DialogTemplateListItems/ShareButtons'
-// import Images from '../DialogTemplateListItems/Images'
-import TnrisDownloadTemplateDownload from './TnrisDownloadTemplateDownload'
+
+import TnrisDownloadTemplateDownloadContainer from '../../containers/TnrisDownloadTemplateDownloadContainer'
+// import TnrisDownloadTemplateDownload from './TnrisDownloadTemplateDownload'
 
 // global sass breakpoint variables to be used in js
 import breakpoints from '../../sass/_breakpoints.scss';
@@ -52,10 +53,11 @@ export default class TnrisDownloadTemplateDetails extends React.Component {
     //                       collection_name={this.props.collection.name} />)
     //                     : "";
 
-    // const downloadMap = this.props.collection.template === 'tnris-download' ? (
-    //                   <TnrisDownloadTemplateDownload collection={this.props.collection} />)
-    //                  : "";
-    const downloadMap = "";
+    const downloadMap = this.props.collection.template === 'tnris-download' ? (
+      <TnrisDownloadTemplateDownloadContainer collectionName={this.props.collection.name}/>
+    ) : "";
+
+    console.log(downloadMap);
 
     console.log(this.props.collection);
 

--- a/src/components/TnrisDownloadTemplate/TnrisDownloadTemplateDetails.jsx
+++ b/src/components/TnrisDownloadTemplate/TnrisDownloadTemplateDetails.jsx
@@ -8,8 +8,9 @@ import Services from '../DialogTemplateListItems/Services'
 import Supplementals from '../DialogTemplateListItems/Supplementals'
 import ShareButtons from '../DialogTemplateListItems/ShareButtons'
 
+// import TnrisDownloadTemplateContainer from '../../containers/TnrisDownloadTemplateContainer'
+import TnrisDownloadTemplateDownload from './TnrisDownloadTemplateDownload'
 import TnrisDownloadTemplateDownloadContainer from '../../containers/TnrisDownloadTemplateDownloadContainer'
-// import TnrisDownloadTemplateDownload from './TnrisDownloadTemplateDownload'
 
 // global sass breakpoint variables to be used in js
 import breakpoints from '../../sass/_breakpoints.scss';
@@ -54,7 +55,9 @@ export default class TnrisDownloadTemplateDetails extends React.Component {
     //                     : "";
 
     const downloadMap = this.props.collection.template === 'tnris-download' ? (
-      <TnrisDownloadTemplateDownloadContainer collectionName={this.props.collection.name}/>
+                          <TnrisDownloadTemplateDownloadContainer
+                            collectionName={this.props.collection.name}
+                             />
     ) : "";
 
     console.log(downloadMap);

--- a/src/components/TnrisDownloadTemplate/TnrisDownloadTemplateDetails.jsx
+++ b/src/components/TnrisDownloadTemplate/TnrisDownloadTemplateDetails.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from 'react'
 
 import Description from '../DialogTemplateListItems/Description'
 import SourceCitation from '../DialogTemplateListItems/SourceCitation'
@@ -11,7 +11,7 @@ import ShareButtons from '../DialogTemplateListItems/ShareButtons'
 import TnrisDownloadTemplateDownloadContainer from '../../containers/TnrisDownloadTemplateDownloadContainer'
 
 // global sass breakpoint variables to be used in js
-import breakpoints from '../../sass/_breakpoints.scss';
+import breakpoints from '../../sass/_breakpoints.scss'
 
 export default class TnrisDownloadTemplateDetails extends React.Component {
   constructor(props) {

--- a/src/components/TnrisDownloadTemplate/TnrisDownloadTemplateDetails.jsx
+++ b/src/components/TnrisDownloadTemplate/TnrisDownloadTemplateDetails.jsx
@@ -7,7 +7,8 @@ import Metadata from '../DialogTemplateListItems/Metadata'
 import Services from '../DialogTemplateListItems/Services'
 import Supplementals from '../DialogTemplateListItems/Supplementals'
 import ShareButtons from '../DialogTemplateListItems/ShareButtons'
-import Images from '../DialogTemplateListItems/Images'
+// import Images from '../DialogTemplateListItems/Images'
+import TnrisDownloadTemplateDownload from './TnrisDownloadTemplateDownload'
 
 // global sass breakpoint variables to be used in js
 import breakpoints from '../../sass/_breakpoints.scss';
@@ -44,12 +45,18 @@ export default class TnrisDownloadTemplateDetails extends React.Component {
   }
 
   render() {
-    const imageCarousel = this.props.collection.images ? (
-                        <Images
-                          thumbnail={this.props.collection.thumbnail_image}
-                          images={this.props.collection.images}
-                          collection_name={this.props.collection.name} />)
-                        : "";
+    // const imageCarousel = this.props.collection.images ? (
+    //                     <Images
+    //                       thumbnail={this.props.collection.thumbnail_image}
+    //                       images={this.props.collection.images}
+    //                       collection_name={this.props.collection.name} />)
+    //                     : "";
+
+    const downloadMap = this.props.collection.template === 'tnris-download' ? (
+                      <TnrisDownloadTemplateDownload collection={this.props.collection} />)
+                     : "";
+
+    console.log(this.props.collection);
 
     const lidarCard = this.props.collection.category.includes('Lidar') ? (
                         <LidarBlurb />)
@@ -85,7 +92,8 @@ export default class TnrisDownloadTemplateDetails extends React.Component {
                             <ShareButtons />
                           </div>
                           <div className='mdc-layout-grid__cell mdc-layout-grid__cell--span-8'>
-                            {imageCarousel}
+                            {/*{imageCarousel}*/}
+                            {downloadMap}
                             <div className="mdc-layout-grid__inner">
                               <div className='mdc-layout-grid__cell mdc-layout-grid__cell--span-8'>
                                 {description}
@@ -98,7 +106,8 @@ export default class TnrisDownloadTemplateDetails extends React.Component {
                         </div>) : (
                         <div className="mdc-layout-grid__inner">
                           <div className='mdc-layout-grid__cell mdc-layout-grid__cell--span-12'>
-                            {imageCarousel}
+                            {/*{imageCarousel}*/}
+                            {downloadMap}
                             <Metadata collection={this.props.collection} />
                             {description}
                             {sourceCitation}

--- a/src/components/TnrisDownloadTemplate/TnrisDownloadTemplateDownload.jsx
+++ b/src/components/TnrisDownloadTemplate/TnrisDownloadTemplateDownload.jsx
@@ -414,7 +414,7 @@ export default class TnrisDownloadTemplateDownload extends React.Component {
       <div className='template-content-div tnris-download-template-download'>
         <nav id='tnris-download-menu' className={menuDisplayClass}></nav>
           <div className='template-content-div-header mdc-typography--headline5'>
-            Download
+            Download Area
           </div>
         <div id='tnris-download-map'></div>
         <TnrisDownloadMapNote />

--- a/src/components/TnrisDownloadTemplate/TnrisDownloadTemplateDownload.jsx
+++ b/src/components/TnrisDownloadTemplate/TnrisDownloadTemplateDownload.jsx
@@ -33,17 +33,23 @@ export default class TnrisDownloadTemplateDownload extends React.Component {
   componentDidMount() {
     // on mount/load, try and launch the map. if the api response with the list
     // of downloadable resources hasn't returned we won't launch it
-    console.log(this.props)
-    // this.createMap()
+    if (this.props.loadingResources === false && this.props.resourceAreaTypes) {
+      this.areaLookup = this.props.resourceAreas;
+      if (window.innerWidth > this.downloadBreakpoint) {
+        this.createMap();
+      }
+    }
+
     // if (this.props.loadingResources === false && this.props.selectedCollectionResources.result.length > 0) {
     //   this.areaLookup = this.props.resourceAreas;
     //   if (window.innerWidth > this.downloadBreakpoint) {
     //     this.createMap();
     //   }
     // }
-    if (this.props.selectedCollectionResources.result && this.props.selectedCollectionResources.result.length === 0) {
-      this.setState({resourceLength:this.props.selectedCollectionResources.result.length});
-    }
+    //
+    // if (this.props.selectedCollectionResources.result && this.props.selectedCollectionResources.result.length === 0) {
+    //   this.setState({resourceLength:this.props.selectedCollectionResources.result.length});
+    // }
   }
 
   componentDidUpdate () {

--- a/src/components/TnrisDownloadTemplate/TnrisDownloadTemplateDownload.jsx
+++ b/src/components/TnrisDownloadTemplate/TnrisDownloadTemplateDownload.jsx
@@ -39,17 +39,6 @@ export default class TnrisDownloadTemplateDownload extends React.Component {
         this.createMap();
       }
     }
-
-    // if (this.props.loadingResources === false && this.props.selectedCollectionResources.result.length > 0) {
-    //   this.areaLookup = this.props.resourceAreas;
-    //   if (window.innerWidth > this.downloadBreakpoint) {
-    //     this.createMap();
-    //   }
-    // }
-    //
-    // if (this.props.selectedCollectionResources.result && this.props.selectedCollectionResources.result.length === 0) {
-    //   this.setState({resourceLength:this.props.selectedCollectionResources.result.length});
-    // }
   }
 
   componentDidUpdate () {

--- a/src/components/TnrisDownloadTemplate/TnrisDownloadTemplateDownload.jsx
+++ b/src/components/TnrisDownloadTemplate/TnrisDownloadTemplateDownload.jsx
@@ -411,8 +411,11 @@ export default class TnrisDownloadTemplateDownload extends React.Component {
     const menuDisplayClass = this.state.areaTypesLength > 1 ? 'mdc-list' : 'mdc-list hidden-layer-menu';
 
     return (
-      <div className='tnris-download-template-download'>
+      <div className='template-content-div tnris-download-template-download'>
         <nav id='tnris-download-menu' className={menuDisplayClass}></nav>
+          <div className='template-content-div-header mdc-typography--headline5'>
+            Download
+          </div>
         <div id='tnris-download-map'></div>
         <TnrisDownloadMapNote />
       </div>

--- a/src/components/TnrisDownloadTemplate/TnrisDownloadTemplateDownload.jsx
+++ b/src/components/TnrisDownloadTemplate/TnrisDownloadTemplateDownload.jsx
@@ -370,6 +370,7 @@ export default class TnrisDownloadTemplateDownload extends React.Component {
       return (
         <div className='tnris-download-template-download'>
           <div className="tnris-download-template-download__mobile">
+            <h3>Download Map Disabled for Mobile Devices</h3>
             <p>
               Due to the average size of data downloads and in consideration of user experience,
               data downloads have been <strong>disabled</strong> for small browser windows and mobile devices.

--- a/src/components/TnrisDownloadTemplate/TnrisDownloadTemplateDownload.jsx
+++ b/src/components/TnrisDownloadTemplate/TnrisDownloadTemplateDownload.jsx
@@ -1,13 +1,12 @@
-import React from 'react';
-import { GridLoader } from 'react-spinners';
-import TnrisDownloadMapNote from './TnrisDownloadMapNote';
+import React from 'react'
+import { GridLoader } from 'react-spinners'
+import TnrisDownloadMapNote from './TnrisDownloadMapNote'
 
-import mapboxgl from 'mapbox-gl';
-import styles from '../../sass/index.scss';
-// import loadingImage from '../../images/loading.gif';
+import mapboxgl from 'mapbox-gl'
+import styles from '../../sass/index.scss'
 
 // global sass breakpoint variables to be used in js
-import breakpoints from '../../sass/_breakpoints.scss';
+import breakpoints from '../../sass/_breakpoints.scss'
 
 // the carto core api is a CDN in the app template HTML (not available as NPM package)
 // so we create a constant to represent it so it's available to the component

--- a/src/components/TnrisDownloadTemplate/TnrisDownloadTemplateDownload.jsx
+++ b/src/components/TnrisDownloadTemplate/TnrisDownloadTemplateDownload.jsx
@@ -414,7 +414,7 @@ export default class TnrisDownloadTemplateDownload extends React.Component {
       <div className='template-content-div tnris-download-template-download'>
         <nav id='tnris-download-menu' className={menuDisplayClass}></nav>
           <div className='template-content-div-header mdc-typography--headline5'>
-            Download Area
+            Download
           </div>
         <div id='tnris-download-map'></div>
         <TnrisDownloadMapNote />

--- a/src/components/TnrisDownloadTemplate/TnrisDownloadTemplateDownload.jsx
+++ b/src/components/TnrisDownloadTemplate/TnrisDownloadTemplateDownload.jsx
@@ -33,12 +33,14 @@ export default class TnrisDownloadTemplateDownload extends React.Component {
   componentDidMount() {
     // on mount/load, try and launch the map. if the api response with the list
     // of downloadable resources hasn't returned we won't launch it
-    if (this.props.loadingResources === false && this.props.selectedCollectionResources.result.length > 0) {
-      this.areaLookup = this.props.resourceAreas;
-      if (window.innerWidth > this.downloadBreakpoint) {
-        this.createMap();
-      }
-    }
+    console.log(this.props)
+    // this.createMap()
+    // if (this.props.loadingResources === false && this.props.selectedCollectionResources.result.length > 0) {
+    //   this.areaLookup = this.props.resourceAreas;
+    //   if (window.innerWidth > this.downloadBreakpoint) {
+    //     this.createMap();
+    //   }
+    // }
     if (this.props.selectedCollectionResources.result && this.props.selectedCollectionResources.result.length === 0) {
       this.setState({resourceLength:this.props.selectedCollectionResources.result.length});
     }

--- a/src/components/TnrisOrderTemplate/TnrisOrderTemplate.jsx
+++ b/src/components/TnrisOrderTemplate/TnrisOrderTemplate.jsx
@@ -140,7 +140,7 @@ export default class TnrisOrderTemplate extends React.Component {
                           aria-selected="false"
                           tabIndex="-1"
                           onClick={() => this.setTemplateView("images")}
-                          title="Order">
+                          title="Images">
                           <span className="mdc-tab__content">images</span>
                           <span className="mdc-tab-indicator">
                             <span

--- a/src/components/TnrisOrderTemplate/TnrisOrderTemplate.jsx
+++ b/src/components/TnrisOrderTemplate/TnrisOrderTemplate.jsx
@@ -1,15 +1,14 @@
-import React from 'react';
-import {MDCTopAppBar} from '@material/top-app-bar/index';
-import {MDCTabBar} from '@material/tab-bar';
-import { MDCMenu } from '@material/menu';
+import React from 'react'
+import {MDCTopAppBar} from '@material/top-app-bar/index'
+import {MDCTabBar} from '@material/tab-bar'
+import { MDCMenu } from '@material/menu'
 
 import TnrisOrderTemplateDetails from './TnrisOrderTemplateDetails'
 
 import Images from '../Images'
 
-// import CountyCoverageContainer from '../../containers/CountyCoverageContainer'
-import ContactContainer from '../../containers/ContactContainer';
-import OrderTnrisDataFormContainer from '../../containers/OrderTnrisDataFormContainer';
+import ContactContainer from '../../containers/ContactContainer'
+import OrderTnrisDataFormContainer from '../../containers/OrderTnrisDataFormContainer'
 
 export default class TnrisOrderTemplate extends React.Component {
   constructor(props) {

--- a/src/components/TnrisOrderTemplate/TnrisOrderTemplate.jsx
+++ b/src/components/TnrisOrderTemplate/TnrisOrderTemplate.jsx
@@ -133,40 +133,24 @@ export default class TnrisOrderTemplate extends React.Component {
                         <span className="mdc-tab__ripple"></span>
                       </button>
 
-                      <button
-                        className="mdc-tab"
-                        role="tab"
-                        aria-selected="false"
-                        tabIndex="-1"
-                        onClick={() => this.setTemplateView("images")}
-                        title="Order">
-                        <span className="mdc-tab__content">images</span>
-                        <span className="mdc-tab-indicator">
-                          <span
-                            className="mdc-tab-indicator__content mdc-tab-indicator__content--underline">
-                          </span>
-                        </span>
-                        <span className="mdc-tab__ripple"></span>
-                      </button>
-
-                      {/* this.props.collection.counties ? (
-                          <button
-                            className="mdc-tab"
-                            role="tab"
-                            aria-selected="false"
-                            tabIndex="-1"
-                            onClick={() => this.setTemplateView("coverage")}
-                            title="Coverage Map">
-                            <span className="mdc-tab__content">coverage</span>
-                            <span className="mdc-tab-indicator">
-                              <span
-                                className="mdc-tab-indicator__content mdc-tab-indicator__content--underline">
-                              </span>
+                      { this.props.collection.images ? (
+                        <button
+                          className="mdc-tab"
+                          role="tab"
+                          aria-selected="false"
+                          tabIndex="-1"
+                          onClick={() => this.setTemplateView("images")}
+                          title="Order">
+                          <span className="mdc-tab__content">images</span>
+                          <span className="mdc-tab-indicator">
+                            <span
+                              className="mdc-tab-indicator__content mdc-tab-indicator__content--underline">
                             </span>
-                            <span className="mdc-tab__ripple"></span>
-                          </button>
+                          </span>
+                          <span className="mdc-tab__ripple"></span>
+                        </button>
                         ) : ""
-                      */}
+                      }
 
                       <button
                         className="mdc-tab"

--- a/src/components/TnrisOrderTemplate/TnrisOrderTemplate.jsx
+++ b/src/components/TnrisOrderTemplate/TnrisOrderTemplate.jsx
@@ -7,7 +7,7 @@ import TnrisOrderTemplateDetails from './TnrisOrderTemplateDetails'
 
 import Images from '../Images'
 
-import CountyCoverageContainer from '../../containers/CountyCoverageContainer'
+// import CountyCoverageContainer from '../../containers/CountyCoverageContainer'
 import ContactContainer from '../../containers/ContactContainer';
 import OrderTnrisDataFormContainer from '../../containers/OrderTnrisDataFormContainer';
 

--- a/src/components/TnrisOrderTemplate/TnrisOrderTemplate.jsx
+++ b/src/components/TnrisOrderTemplate/TnrisOrderTemplate.jsx
@@ -5,6 +5,8 @@ import { MDCMenu } from '@material/menu';
 
 import TnrisOrderTemplateDetails from './TnrisOrderTemplateDetails'
 
+import Images from '../Images'
+
 import CountyCoverageContainer from '../../containers/CountyCoverageContainer'
 import ContactContainer from '../../containers/ContactContainer';
 import OrderTnrisDataFormContainer from '../../containers/OrderTnrisDataFormContainer';
@@ -33,7 +35,7 @@ export default class TnrisOrderTemplate extends React.Component {
       case 'details':
         tabIndex = 0;
         break;
-      case 'coverage':
+      case 'images':
         tabIndex = 1;
         break;
       case 'order':
@@ -59,8 +61,13 @@ export default class TnrisOrderTemplate extends React.Component {
       case 'details':
         showComponent = <TnrisOrderTemplateDetails collection={this.props.collection} />;
         break;
-      case 'coverage':
-        showComponent = <CountyCoverageContainer counties={this.props.collection.counties} />;
+      case 'images':
+        // showComponent = <CountyCoverageContainer counties={this.props.collection.counties} />;
+        showComponent = (
+          <Images
+            thumbnail={this.props.collection.thumbnail_image}
+            images={this.props.collection.images} />
+        )
         break;
       case 'order':
         showComponent = (
@@ -126,7 +133,23 @@ export default class TnrisOrderTemplate extends React.Component {
                         <span className="mdc-tab__ripple"></span>
                       </button>
 
-                      { this.props.collection.counties ? (
+                      <button
+                        className="mdc-tab"
+                        role="tab"
+                        aria-selected="false"
+                        tabIndex="-1"
+                        onClick={() => this.setTemplateView("images")}
+                        title="Order">
+                        <span className="mdc-tab__content">images</span>
+                        <span className="mdc-tab-indicator">
+                          <span
+                            className="mdc-tab-indicator__content mdc-tab-indicator__content--underline">
+                          </span>
+                        </span>
+                        <span className="mdc-tab__ripple"></span>
+                      </button>
+
+                      {/* this.props.collection.counties ? (
                           <button
                             className="mdc-tab"
                             role="tab"
@@ -143,7 +166,7 @@ export default class TnrisOrderTemplate extends React.Component {
                             <span className="mdc-tab__ripple"></span>
                           </button>
                         ) : ""
-                      }
+                      */}
 
                       <button
                         className="mdc-tab"
@@ -187,13 +210,17 @@ export default class TnrisOrderTemplate extends React.Component {
                        onClick={() => this.setTemplateView("details")}>Details
                        {/*<i className="mdc-tab__icon material-icons">details</i>*/}
                     </div>
-                    { this.props.collection.counties ? (
+                    <div className={this.state.view === 'images' ? 'mdc-list-item  mdc-list-item--activated' : 'mdc-list-item'}
+                       onClick={() => this.setTemplateView("images")}>Images
+                       {/*<i className="mdc-tab__icon material-icons">details</i>*/}
+                    </div>
+                    {/* this.props.collection.counties ? (
                       <div className={this.state.view === 'coverage' ? 'mdc-list-item  mdc-list-item--activated' : 'mdc-list-item'}
                          onClick={() => this.setTemplateView("coverage")}>Coverage
-                         {/*<i className="mdc-tab__icon material-icons">details</i>*/}
+
                       </div>
                       ) : ""
-                    }
+                    */}
                     <div className={this.state.view === 'order' ? 'mdc-list-item  mdc-list-item--activated' : 'mdc-list-item'}
                        onClick={() => this.setTemplateView("order")}>Order
                        {/*<i className="mdc-tab__icon material-icons">shopping_basket</i>*/}

--- a/src/components/TnrisOrderTemplate/TnrisOrderTemplate.jsx
+++ b/src/components/TnrisOrderTemplate/TnrisOrderTemplate.jsx
@@ -62,7 +62,6 @@ export default class TnrisOrderTemplate extends React.Component {
         showComponent = <TnrisOrderTemplateDetails collection={this.props.collection} />;
         break;
       case 'images':
-        // showComponent = <CountyCoverageContainer counties={this.props.collection.counties} />;
         showComponent = (
           <Images
             thumbnail={this.props.collection.thumbnail_image}
@@ -140,8 +139,8 @@ export default class TnrisOrderTemplate extends React.Component {
                           aria-selected="false"
                           tabIndex="-1"
                           onClick={() => this.setTemplateView("images")}
-                          title="Images">
-                          <span className="mdc-tab__content">images</span>
+                          title="Preview">
+                          <span className="mdc-tab__content">preview</span>
                           <span className="mdc-tab-indicator">
                             <span
                               className="mdc-tab-indicator__content mdc-tab-indicator__content--underline">

--- a/src/components/TnrisOrderTemplate/TnrisOrderTemplateDetails.jsx
+++ b/src/components/TnrisOrderTemplate/TnrisOrderTemplateDetails.jsx
@@ -7,7 +7,8 @@ import Metadata from '../DialogTemplateListItems/Metadata'
 import Services from '../DialogTemplateListItems/Services'
 import Supplementals from '../DialogTemplateListItems/Supplementals'
 import ShareButtons from '../DialogTemplateListItems/ShareButtons'
-import Images from '../DialogTemplateListItems/Images'
+
+import CountyCoverageContainer from '../../containers/CountyCoverageContainer'
 
 // global sass breakpoint variables to be used in js
 import breakpoints from '../../sass/_breakpoints.scss';
@@ -44,11 +45,16 @@ export default class TnrisDownloadTemplateDetails extends React.Component {
   }
 
   render() {
-    const imageCarousel = this.props.collection.images ? (
-                        <Images
-                          thumbnail={this.props.collection.thumbnail_image}
-                          images={this.props.collection.images} />)
-                        : "";
+    // const imageCarousel = this.props.collection.images ? (
+    //                     <Images
+    //                       thumbnail={this.props.collection.thumbnail_image}
+    //                       images={this.props.collection.images} />)
+    //                     : "";
+    console.log(this.props.collection.counties);
+
+    const countyCoverage = this.props.collection.counties ? (
+      <CountyCoverageContainer counties={this.props.collection.counties} />
+    ) : "";
 
     const lidarCard = this.props.collection.category.includes('Lidar') ? (
                         <LidarBlurb />)
@@ -84,7 +90,8 @@ export default class TnrisDownloadTemplateDetails extends React.Component {
                               <ShareButtons />
                             </div>
                             <div className='mdc-layout-grid__cell mdc-layout-grid__cell--span-8'>
-                              {imageCarousel}
+                              {/*{imageCarousel}*/}
+                              {countyCoverage}
                               <div className="mdc-layout-grid__inner">
                                 <div className='mdc-layout-grid__cell mdc-layout-grid__cell--span-8'>
                                   {description}
@@ -97,7 +104,8 @@ export default class TnrisDownloadTemplateDetails extends React.Component {
                           </div>) : (
                           <div className="mdc-layout-grid__inner">
                             <div className='mdc-layout-grid__cell mdc-layout-grid__cell--span-12'>
-                              {imageCarousel}
+                              {/*{imageCarousel}*/}
+                              {countyCoverage}
                               <Metadata collection={this.props.collection} />
                               {description}
                               {sourceCitation}

--- a/src/components/TnrisOrderTemplate/TnrisOrderTemplateDetails.jsx
+++ b/src/components/TnrisOrderTemplate/TnrisOrderTemplateDetails.jsx
@@ -11,7 +11,7 @@ import ShareButtons from '../DialogTemplateListItems/ShareButtons'
 import CountyCoverageContainer from '../../containers/CountyCoverageContainer'
 
 // global sass breakpoint variables to be used in js
-import breakpoints from '../../sass/_breakpoints.scss';
+import breakpoints from '../../sass/_breakpoints.scss'
 
 export default class TnrisDownloadTemplateDetails extends React.Component {
   constructor(props) {

--- a/src/components/TnrisOrderTemplate/TnrisOrderTemplateDetails.jsx
+++ b/src/components/TnrisOrderTemplate/TnrisOrderTemplateDetails.jsx
@@ -45,11 +45,6 @@ export default class TnrisDownloadTemplateDetails extends React.Component {
   }
 
   render() {
-    // const imageCarousel = this.props.collection.images ? (
-    //                     <Images
-    //                       thumbnail={this.props.collection.thumbnail_image}
-    //                       images={this.props.collection.images} />)
-    //                     : "";
 
     const countyCoverage = this.props.collection.counties ? (
                               <CountyCoverageContainer counties={this.props.collection.counties} />

--- a/src/components/TnrisOrderTemplate/TnrisOrderTemplateDetails.jsx
+++ b/src/components/TnrisOrderTemplate/TnrisOrderTemplateDetails.jsx
@@ -50,11 +50,15 @@ export default class TnrisDownloadTemplateDetails extends React.Component {
     //                       thumbnail={this.props.collection.thumbnail_image}
     //                       images={this.props.collection.images} />)
     //                     : "";
-    console.log(this.props.collection.counties);
 
     const countyCoverage = this.props.collection.counties ? (
       <CountyCoverageContainer counties={this.props.collection.counties} />
-    ) : "";
+    ) : (
+      <div>
+        <p>
+          There was an error loading the County Coverage map. Please try refreshing the page.
+        </p>
+      </div>);
 
     const lidarCard = this.props.collection.category.includes('Lidar') ? (
                         <LidarBlurb />)

--- a/src/components/TnrisOrderTemplate/TnrisOrderTemplateDetails.jsx
+++ b/src/components/TnrisOrderTemplate/TnrisOrderTemplateDetails.jsx
@@ -52,13 +52,8 @@ export default class TnrisDownloadTemplateDetails extends React.Component {
     //                     : "";
 
     const countyCoverage = this.props.collection.counties ? (
-      <CountyCoverageContainer counties={this.props.collection.counties} />
-    ) : (
-      <div>
-        <p>
-          There was an error loading the County Coverage map. Please try refreshing the page.
-        </p>
-      </div>);
+                              <CountyCoverageContainer counties={this.props.collection.counties} />
+                            ) : "";
 
     const lidarCard = this.props.collection.category.includes('Lidar') ? (
                         <LidarBlurb />)

--- a/src/components/TnrisOutsideEntityTemplate/TnrisOutsideEntityTemplate.jsx
+++ b/src/components/TnrisOutsideEntityTemplate/TnrisOutsideEntityTemplate.jsx
@@ -1,10 +1,10 @@
-import React from 'react';
-import {MDCTopAppBar} from '@material/top-app-bar/index';
-import {MDCTabBar} from '@material/tab-bar';
-import { MDCMenu } from '@material/menu';
+import React from 'react'
+import {MDCTopAppBar} from '@material/top-app-bar/index'
+import {MDCTabBar} from '@material/tab-bar'
+import {MDCMenu} from '@material/menu'
 
-import TnrisOutsideEntityTemplateDetails from './TnrisOutsideEntityTemplateDetails';
-import ContactOutsideContainer from '../../containers/ContactOutsideContainer';
+import TnrisOutsideEntityTemplateDetails from './TnrisOutsideEntityTemplateDetails'
+import ContactOutsideContainer from '../../containers/ContactOutsideContainer'
 
 export default class TnrisOutsideEntityTemplate extends React.Component {
   constructor(props) {

--- a/src/components/TnrisOutsideEntityTemplate/TnrisOutsideEntityTemplateDetails.jsx
+++ b/src/components/TnrisOutsideEntityTemplate/TnrisOutsideEntityTemplateDetails.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from 'react'
 
 import Description from '../DialogTemplateListItems/Description'
 import Metadata from '../DialogTemplateListItems/Metadata'
@@ -7,7 +7,7 @@ import Images from '../Images'
 import OeServices from '../DialogTemplateListItems/OeServices'
 
 // global sass breakpoint variables to be used in js
-import breakpoints from '../../sass/_breakpoints.scss';
+import breakpoints from '../../sass/_breakpoints.scss'
 
 export default class TnrisOutsideEntityTemplateDetails extends React.Component {
 

--- a/src/components/TnrisOutsideEntityTemplate/TnrisOutsideEntityTemplateDetails.jsx
+++ b/src/components/TnrisOutsideEntityTemplate/TnrisOutsideEntityTemplateDetails.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import Description from '../DialogTemplateListItems/Description'
 import Metadata from '../DialogTemplateListItems/Metadata'
 import ShareButtons from '../DialogTemplateListItems/ShareButtons'
-import Images from '../DialogTemplateListItems/Images'
+import Images from '../Images'
 import OeServices from '../DialogTemplateListItems/OeServices'
 
 // global sass breakpoint variables to be used in js

--- a/src/components/ToolDrawer.jsx
+++ b/src/components/ToolDrawer.jsx
@@ -1,13 +1,13 @@
-import React from 'react';
-import { MDCDrawer } from "@material/drawer";
+import React from 'react'
+import { MDCDrawer } from "@material/drawer"
 
-import CollectionFilterContainer from '../containers/CollectionFilterContainer';
-import CollectionSorterContainer from '../containers/CollectionSorterContainer';
-import CollectionTimesliderContainer from '../containers/CollectionTimesliderContainer';
+import CollectionFilterContainer from '../containers/CollectionFilterContainer'
+import CollectionSorterContainer from '../containers/CollectionSorterContainer'
+import CollectionTimesliderContainer from '../containers/CollectionTimesliderContainer'
 
-import ShareButtons from './DialogTemplateListItems/ShareButtons';
+import ShareButtons from './DialogTemplateListItems/ShareButtons'
 
-import ThemeChooserContainer from '../containers/ThemeChooserContainer';
+import ThemeChooserContainer from '../containers/ThemeChooserContainer'
 
 export default class ToolDrawer extends React.Component {
 

--- a/src/containers/CatalogCardContainer.jsx
+++ b/src/containers/CatalogCardContainer.jsx
@@ -1,10 +1,11 @@
-import { connect } from 'react-redux';
+import { connect } from 'react-redux'
 
 import { catalogActions,
          collectionActions,
          collectionSearcherActions,
-         urlTrackerActions } from '../actions';
-import CatalogCard from '../components/CatalogCard';
+         urlTrackerActions } from '../actions'
+         
+import CatalogCard from '../components/CatalogCard'
 
 const mapStateToProps = state => ({
   selectedCollection: state.collections.selectedCollection

--- a/src/containers/CatalogContainer.jsx
+++ b/src/containers/CatalogContainer.jsx
@@ -1,18 +1,19 @@
-import { connect } from 'react-redux';
-import { withRouter } from 'react-router';
+import { connect } from 'react-redux'
+import { withRouter } from 'react-router'
 
-import Catalog from '../components/Catalog';
+import Catalog from '../components/Catalog'
 import {
   catalogActions,
   collectionActions,
   colorThemeActions,
   orderCartActions,
   resourceActions,
-  toolDrawerActions } from '../actions';
+  toolDrawerActions } from '../actions'
+
 import {
   getAllCollections,
   getSortedCollections
-} from '../selectors/collectionSelectors';
+} from '../selectors/collectionSelectors'
 
 const mapStateToProps = (state) => ({
   collections: getAllCollections(state),

--- a/src/containers/CollectionFilterContainer.jsx
+++ b/src/containers/CollectionFilterContainer.jsx
@@ -1,14 +1,15 @@
-import { connect } from 'react-redux';
-import { withRouter } from 'react-router';
+import { connect } from 'react-redux'
+import { withRouter } from 'react-router'
 
 import {
   catalogActions,
   collectionFilterActions,
   collectionFilterMapActions,
   urlTrackerActions
-} from '../actions';
-import CollectionFilter from '../components/CollectionFilter';
-import { getCollectionFilterChoices } from '../selectors/collectionSelectors';
+} from '../actions'
+
+import CollectionFilter from '../components/CollectionFilter'
+import { getCollectionFilterChoices } from '../selectors/collectionSelectors'
 
 const mapStateToProps = (state) => ({
   collectionFilter: state.collectionFilter.collectionFilter,

--- a/src/containers/CollectionFilterMapContainer.jsx
+++ b/src/containers/CollectionFilterMapContainer.jsx
@@ -1,12 +1,13 @@
-import { connect } from 'react-redux';
-import { withRouter } from 'react-router';
+import { connect } from 'react-redux'
+import { withRouter } from 'react-router'
 
 import {
   catalogActions,
   collectionFilterMapActions,
   urlTrackerActions
-} from '../actions';
-import CollectionFilterMap from '../components/CollectionFilterMap';
+} from '../actions'
+
+import CollectionFilterMap from '../components/CollectionFilterMap'
 
 const mapStateToProps = state => ({
   collectionFilterMapAoi: state.collectionFilterMap.collectionFilterMapAoi,

--- a/src/containers/CollectionFilterMapViewContainer.jsx
+++ b/src/containers/CollectionFilterMapViewContainer.jsx
@@ -1,9 +1,9 @@
-import { connect } from 'react-redux';
+import { connect } from 'react-redux'
 
-import CollectionFilterMapView from '../components/CollectionFilterMapView';
+import CollectionFilterMapView from '../components/CollectionFilterMapView'
 
 import { catalogActions,
-         urlTrackerActions } from '../actions';
+         urlTrackerActions } from '../actions'
 
 const mapStateToProps = state => ({
   previousUrl: state.urlTracker.previousUrl,

--- a/src/containers/CollectionSearcherContainer.jsx
+++ b/src/containers/CollectionSearcherContainer.jsx
@@ -1,18 +1,20 @@
-import { connect } from 'react-redux';
-import { withRouter } from 'react-router';
+import { connect } from 'react-redux'
+import { withRouter } from 'react-router'
 
-import CollectionSearcher from '../components/CollectionSearcher';
+import CollectionSearcher from '../components/CollectionSearcher'
+
 import {
   catalogActions,
   collectionActions,
   collectionSearcherActions,
   urlTrackerActions,
   colorThemeActions
-} from '../actions';
+} from '../actions'
+
 import {
   getAllCollections,
   getSearchSuggestions
-} from '../selectors/collectionSelectors';
+} from '../selectors/collectionSelectors'
 
 const mapStateToProps = (state) => ({
   collections: getAllCollections(state),

--- a/src/containers/CollectionSorterContainer.jsx
+++ b/src/containers/CollectionSorterContainer.jsx
@@ -1,7 +1,7 @@
-import { connect } from 'react-redux';
-import { withRouter } from 'react-router';
+import {connect} from 'react-redux'
+import {withRouter} from 'react-router'
 
-import { collectionSorterActions, urlTrackerActions } from '../actions';
+import {collectionSorterActions, urlTrackerActions} from '../actions'
 import CollectionSorter from '../components/CollectionSorter';
 
 const mapStateToProps = state => ({

--- a/src/containers/CollectionTimesliderContainer.jsx
+++ b/src/containers/CollectionTimesliderContainer.jsx
@@ -1,10 +1,10 @@
-import { connect } from 'react-redux';
-import { withRouter } from 'react-router';
+import {connect} from 'react-redux'
+import {withRouter} from 'react-router'
 
 
-import CollectionTimeslider from '../components/CollectionTimeslider';
-import { collectionTimesliderActions, urlTrackerActions } from '../actions';
-import { getCollectionTimesliderRange } from '../selectors/collectionSelectors';
+import CollectionTimeslider from '../components/CollectionTimeslider'
+import {collectionTimesliderActions, urlTrackerActions} from '../actions'
+import {getCollectionTimesliderRange} from '../selectors/collectionSelectors'
 
 const mapStateToProps = (state) => ({
   collectionTimeslider: state.collectionTimeslider.collectionTimeslider,

--- a/src/containers/ContactContainer.jsx
+++ b/src/containers/ContactContainer.jsx
@@ -1,7 +1,7 @@
-import { connect } from 'react-redux';
+import {connect} from 'react-redux'
 
-import { contactActions } from '../actions';
-import ContactTnrisForm from '../components/ContactTnrisForm';
+import {contactActions} from '../actions'
+import ContactTnrisForm from '../components/ContactTnrisForm'
 
 const mapStateToProps = state => ({
   submitStatus: state.contact.submitting,

--- a/src/containers/ContactOutsideContainer.jsx
+++ b/src/containers/ContactOutsideContainer.jsx
@@ -1,7 +1,7 @@
-import { connect } from 'react-redux';
+import {connect} from 'react-redux'
 
-import { contactActions } from '../actions';
-import ContactOutsideForm from '../components/ContactOutsideForm';
+import {contactActions} from '../actions'
+import ContactOutsideForm from '../components/ContactOutsideForm'
 
 const mapStateToProps = state => ({
   submitStatus: state.contact.submitting,

--- a/src/containers/CountyCoverageContainer.jsx
+++ b/src/containers/CountyCoverageContainer.jsx
@@ -1,6 +1,6 @@
-import { connect } from 'react-redux';
+import {connect} from 'react-redux'
 
-import CountyCoverage from '../components/DialogTemplateListItems/CountyCoverage';
+import CountyCoverage from '../components/DialogTemplateListItems/CountyCoverage'
 
 const mapStateToProps = state => ({
   theme: state.colorTheme.theme

--- a/src/containers/FooterContainer.jsx
+++ b/src/containers/FooterContainer.jsx
@@ -1,6 +1,6 @@
-import { connect } from 'react-redux';
+import {connect} from 'react-redux'
 
-import Footer from '../components/Footer';
+import Footer from '../components/Footer'
 
 const mapStateToProps = state => ({
   theme: state.colorTheme.theme,

--- a/src/containers/HeaderContainer.jsx
+++ b/src/containers/HeaderContainer.jsx
@@ -1,12 +1,10 @@
-import { connect } from 'react-redux';
-import { withRouter } from 'react-router';
+import {connect} from 'react-redux'
+import {withRouter} from 'react-router'
 
-import { catalogActions,
-         urlTrackerActions } from '../actions';
-import {
-  getAllCollections
-} from '../selectors/collectionSelectors';
-import Header from '../components/Header';
+import {catalogActions, urlTrackerActions} from '../actions'
+import {getAllCollections} from '../selectors/collectionSelectors'
+
+import Header from '../components/Header'
 
 const mapStateToProps = state => ({
   collections: getAllCollections(state),

--- a/src/containers/NotFoundContainer.jsx
+++ b/src/containers/NotFoundContainer.jsx
@@ -1,7 +1,7 @@
-import { connect } from 'react-redux';
+import {connect} from 'react-redux'
 
-import NotFound from '../components/NotFound';
-import { catalogActions } from '../actions';
+import NotFound from '../components/NotFound'
+import {catalogActions} from '../actions'
 
 const mapStateToProps = (state) => ({
   view: state.catalog.view

--- a/src/containers/OrderCartContainer.jsx
+++ b/src/containers/OrderCartContainer.jsx
@@ -1,12 +1,13 @@
-import { connect } from 'react-redux';
+import {connect} from 'react-redux'
 
-import OrderCart from '../components/OrderCart';
+import OrderCart from '../components/OrderCart'
 
-import { catalogActions,
-         collectionActions,
-         orderCartActions,
-         urlTrackerActions } from '../actions';
-import { getAllCollections } from '../selectors/collectionSelectors';
+import {catalogActions,
+        collectionActions,
+        orderCartActions,
+        urlTrackerActions} from '../actions'
+
+import {getAllCollections} from '../selectors/collectionSelectors'
 
 const mapStateToProps = state => ({
   collections: getAllCollections(state),

--- a/src/containers/OrderCartViewContainer.jsx
+++ b/src/containers/OrderCartViewContainer.jsx
@@ -1,10 +1,10 @@
-import { connect } from 'react-redux';
+import {connect} from 'react-redux'
 
-import OrderCartView from '../components/OrderCartView';
+import OrderCartView from '../components/OrderCartView'
 
-import { catalogActions,
-         collectionActions,
-         urlTrackerActions } from '../actions';
+import {catalogActions,
+        collectionActions,
+        urlTrackerActions} from '../actions'
 
 const mapStateToProps = state => ({
   previousUrl: state.urlTracker.previousUrl

--- a/src/containers/OrderTnrisDataFormContainer.jsx
+++ b/src/containers/OrderTnrisDataFormContainer.jsx
@@ -1,8 +1,8 @@
-import { connect } from 'react-redux';
+import {connect} from 'react-redux'
 
-import { orderCartActions } from '../actions';
-import { getAllCollections } from '../selectors/collectionSelectors';
-import OrderTnrisDataForm from '../components/OrderTnrisDataForm';
+import {orderCartActions} from '../actions'
+import {getAllCollections} from '../selectors/collectionSelectors'
+import OrderTnrisDataForm from '../components/OrderTnrisDataForm'
 
 const mapStateToProps = state => ({
   collections: getAllCollections(state),

--- a/src/containers/ThemeChooserContainer.jsx
+++ b/src/containers/ThemeChooserContainer.jsx
@@ -1,7 +1,7 @@
-import { connect } from 'react-redux';
+import {connect} from 'react-redux'
 
-import { colorThemeActions } from '../actions';
-import ThemeChooser from '../components/ThemeChooser';
+import {colorThemeActions} from '../actions'
+import ThemeChooser from '../components/ThemeChooser'
 
 const mapStateToProps = state => ({
   theme: state.colorTheme.theme,

--- a/src/containers/TnrisDownloadTemplateContainer.jsx
+++ b/src/containers/TnrisDownloadTemplateContainer.jsx
@@ -1,7 +1,7 @@
-import { connect } from 'react-redux';
+import {connect} from 'react-redux'
 
-import { collectionActions } from '../actions';
-import TnrisDownloadTemplate from '../components/TnrisDownloadTemplate/TnrisDownloadTemplate';
+import {collectionActions} from '../actions'
+import TnrisDownloadTemplate from '../components/TnrisDownloadTemplate/TnrisDownloadTemplate'
 
 const mapStateToProps = state => ({});
 

--- a/src/containers/TnrisDownloadTemplateDownloadContainer.jsx
+++ b/src/containers/TnrisDownloadTemplateDownloadContainer.jsx
@@ -1,8 +1,9 @@
-import { connect } from 'react-redux';
-import { getResourceAreas,
-         getResourceAreaTypes
-       } from '../selectors/resourceSelectors';
-import TnrisDownloadTemplateDownload from '../components/TnrisDownloadTemplate/TnrisDownloadTemplateDownload';
+import {connect} from 'react-redux'
+import {getResourceAreas,
+        getResourceAreaTypes
+       } from '../selectors/resourceSelectors'
+
+import TnrisDownloadTemplateDownload from '../components/TnrisDownloadTemplate/TnrisDownloadTemplateDownload'
 
 const mapStateToProps = state => ({
   loadingResources: state.collections.loadingResources,

--- a/src/containers/TnrisOrderTemplateOrderContainer.jsx
+++ b/src/containers/TnrisOrderTemplateOrderContainer.jsx
@@ -1,9 +1,9 @@
-import { connect } from 'react-redux';
-import { getResourceAreas,
-         getResourceAreaTypes
-       } from '../selectors/resourceSelectors';
-import TnrisOrderTemplateOrder from '../components/TnrisOrderTemplate/TnrisOrderTemplateOrder';
-// import OrderTnrisDataForm from '../components/OrderTnrisDataForm';
+import {connect} from 'react-redux'
+import {getResourceAreas,
+        getResourceAreaTypes
+       } from '../selectors/resourceSelectors'
+
+import TnrisOrderTemplateOrder from '../components/TnrisOrderTemplate/TnrisOrderTemplateOrder'
 
 const mapStateToProps = state => ({
   loadingResources: state.collections.loadingResources,

--- a/src/containers/ToolDrawerContainer.jsx
+++ b/src/containers/ToolDrawerContainer.jsx
@@ -1,5 +1,5 @@
-import { connect } from 'react-redux';
-import { withRouter } from 'react-router';
+import {connect} from 'react-redux'
+import {withRouter} from 'react-router'
 
 import {
   collectionFilterActions,
@@ -7,10 +7,11 @@ import {
   collectionSorterActions,
   collectionTimesliderActions,
   urlTrackerActions
-} from '../actions';
-import { getCollectionTimesliderRange } from '../selectors/collectionSelectors';
+} from '../actions'
 
-import ToolDrawer from '../components/ToolDrawer';
+import {getCollectionTimesliderRange} from '../selectors/collectionSelectors'
+
+import ToolDrawer from '../components/ToolDrawer'
 
 const mapStateToProps = (state) => ({
   collectionFilter: state.collectionFilter.collectionFilter,

--- a/src/sass/_collectionTemplateDetails.scss
+++ b/src/sass/_collectionTemplateDetails.scss
@@ -102,59 +102,6 @@ shared styles for collection TemplateDetails components
     }
     // end source citation component
 
-    // nested images (image carousel) component - BEGIN
-    // used by all but historicalAerialTemplateDetails
-    .carousel {
-
-      .control-next.control-arrow:before {
-        border-left: 20px solid #fff;
-      }
-
-      .control-prev.control-arrow:before {
-        border-right: 20px solid #fff;
-      }
-
-      .control-arrow:before {
-        border-top: 20px solid transparent;
-        border-bottom: 20px solid transparent;
-      }
-
-      .control-arrow.control-next {
-        margin-right: 0;
-      }
-
-      .control-arrow.control-prev {
-        margin-left: 0;
-      }
-
-      .control-arrow {
-        opacity: 0.8;
-      }
-
-      p.carousel-status {
-        font-size: 16px;
-        font-weight: bold;
-        text-shadow: 2px 2px #333;
-      }
-    }
-
-    .carousel-image {
-      // force each image to be in 16:9 aspect ratio container
-      padding-bottom: 56.25%; /* 16:9 Aspect Ratio */
-      overflow: hidden;
-      position: relative;
-    }
-
-    .carousel-image > img {
-      position: absolute;
-      display: block;
-      width: 100%;
-      height: auto;
-      top: 50%; /* 50% from the top of the container */
-      transform: translateY(-50%); /* -50% of the height of the image */
-    }
-    // nested images (image carousel) component - END
-
     // nested metadata list component - BEGIN
     .mdc-list {
 

--- a/src/sass/_collectionTemplates.scss
+++ b/src/sass/_collectionTemplates.scss
@@ -97,8 +97,8 @@ shared styles for collection base Template components
 
 // template images - used for download, historical and order
 .tnris-template-images {
-  padding-top: 20px;
-  max-width: 1250px;
+  padding-top: 10px;
+  max-width: 1200px;
   margin: 0 auto;
 
   // nested images (image carousel) component - BEGIN

--- a/src/sass/_collectionTemplates.scss
+++ b/src/sass/_collectionTemplates.scss
@@ -94,3 +94,68 @@ shared styles for collection base Template components
   }
   // header element - END
 }
+
+// template images - used for download, historical and order
+.tnris-template-images {
+
+  // nested images (image carousel) component - BEGIN
+  .image-container {
+    padding: 0 40px 0 40px;
+
+    @media (max-width: $breakpoint-tablet) {
+      padding: 0 15px 0 15px;
+    }
+
+    .carousel.carousel-slider {
+
+      .control-next.control-arrow:before {
+        border-left: 20px solid #fff;
+      }
+
+      .control-prev.control-arrow:before {
+        border-right: 20px solid #fff;
+      }
+
+      .control-arrow:before {
+        border-top: 20px solid transparent;
+        border-bottom: 20px solid transparent;
+      }
+
+      .control-arrow.control-next {
+        margin-right: 0;
+      }
+
+      .control-arrow.control-prev {
+        margin-left: 0;
+      }
+
+      .control-arrow {
+        opacity: 0.8;
+      }
+
+      p.carousel-status {
+        font-size: 16px;
+        font-weight: bold;
+        text-shadow: 2px 2px #333;
+      }
+    }
+
+    .carousel-image {
+      // force each image to be in 16:9 aspect ratio container
+      padding-bottom: 56.25%; /* 16:9 Aspect Ratio */
+      overflow: hidden;
+      position: relative;
+      max-height: 80vh;
+    }
+
+    .carousel-image > img {
+      position: absolute;
+      display: block;
+      width: 100%;
+      height: auto;
+      top: 50%; /* 50% from the top of the container */
+      transform: translateY(-50%); /* -50% of the height of the image */
+    }
+  }
+  // nested images (image carousel) component - END
+}

--- a/src/sass/_collectionTemplates.scss
+++ b/src/sass/_collectionTemplates.scss
@@ -97,6 +97,9 @@ shared styles for collection base Template components
 
 // template images - used for download, historical and order
 .tnris-template-images {
+  padding-top: 20px;
+  max-width: 1250px;
+  margin: 0 auto;
 
   // nested images (image carousel) component - BEGIN
   .image-container {

--- a/src/sass/_countyCoverageMap.scss
+++ b/src/sass/_countyCoverageMap.scss
@@ -11,6 +11,7 @@ styles for component: CountyCoverage
     width: auto;
     height: 55vh;
     top: 0;
+    margin: 8px;
 
     .mapboxgl-canvas {
       height: 100% !important;
@@ -33,54 +34,13 @@ styles for component: CountyCoverage
     display: block;
     top: 9px;
     z-index: 5;
-    left: 50px;
+    left: 60px;
     border-radius: 6px;
     box-sizing: border-box;
     border: 1px solid rgba(0,0,0,0.4);
     padding: 3px;
     text-align: center;
     max-width: 500px;
-    // fade out notice div after 5 secs
-    // -webkit-animation: fadeOut 2s forwards;
-    // animation: fadeOut 2s forwards;
-    // -webkit-animation-delay: 5s;
-    // animation-delay: 5s;
-
-    // .show-notice {
-    //   opacity: 1;
-    // }
-    //
-    // .hide {
-    //   display: none;
-    // }
-    //
-    // .visual-hide {
-    //   opacity: 0;
-    // }
   }
-
-  // fadeOut keyframe used in coverage notice above
-  // @keyframes fadeOut {
-  //   from {
-  //     display: block;
-  //     opacity: 1;
-  //   }
-  //   to {
-  //     display: none;
-  //     opacity: 0;
-  //   }
-  // }
-
-  // fade out keyframe for -webkit used in coverage notice above
-  // @-webkit-keyframes fadeOut {
-  //   from {
-  //     display: block;
-  //     opacity: 1;
-  //   }
-  //   to {
-  //     display: none;
-  //     opacity: 0;
-  //   }
-  // }
 
 }

--- a/src/sass/_countyCoverageMap.scss
+++ b/src/sass/_countyCoverageMap.scss
@@ -41,22 +41,22 @@ styles for component: CountyCoverage
     text-align: center;
     max-width: 500px;
     // fade out notice div after 5 secs
-    -webkit-animation: fadeOut 2s forwards;
-    animation: fadeOut 2s forwards;
-    -webkit-animation-delay: 5s;
-    animation-delay: 5s;
+    // -webkit-animation: fadeOut 2s forwards;
+    // animation: fadeOut 2s forwards;
+    // -webkit-animation-delay: 5s;
+    // animation-delay: 5s;
 
-    .show-notice {
-      opacity: 1;
-    }
-
-    .hide {
-      display: none;
-    }
-
-    .visual-hide {
-      opacity: 0;
-    }
+    // .show-notice {
+    //   opacity: 1;
+    // }
+    //
+    // .hide {
+    //   display: none;
+    // }
+    //
+    // .visual-hide {
+    //   opacity: 0;
+    // }
   }
 
   // fadeOut keyframe used in coverage notice above

--- a/src/sass/_countyCoverageMap.scss
+++ b/src/sass/_countyCoverageMap.scss
@@ -11,7 +11,6 @@ styles for component: CountyCoverage
     width: auto;
     height: 55vh;
     top: 0;
-    margin: 8px;
 
     .mapboxgl-canvas {
       height: 100% !important;
@@ -31,16 +30,37 @@ styles for component: CountyCoverage
     background: $main-background;
     color: $nest-text;
     position: absolute;
-    // display: block;
-    top: 9px;
-    z-index: 5;
-    left: 60px;
-    border-radius: 6px;
-    // box-sizing: border-box;
-    border: 1px solid rgba(0,0,0,0.4);
+    z-index: 2;
+    top: 145px;
+    left: 16px;
+    border-radius: 5px;
+    border: 1.5px solid rgba(0,0,0,0.15);
     padding: 3px;
-    text-align: center;
-    max-width: 500px;
+    line-height: 12px;
+    max-width: 200px;
+
+    .close-icon {
+      cursor: pointer;
+      float: left;
+      border-radius: 3px;
+
+      &:hover {
+        background-color: #ccc;
+      }
+    }
+
+    i {
+      cursor: pointer;
+      font-size: 25px;
+    }
+
+    p {
+      margin: 0;
+      line-height: 20px;
+      padding: 5px;
+      width: auto;
+      text-align: center;
+    }
   }
 
 }

--- a/src/sass/_countyCoverageMap.scss
+++ b/src/sass/_countyCoverageMap.scss
@@ -31,12 +31,12 @@ styles for component: CountyCoverage
     background: $main-background;
     color: $nest-text;
     position: absolute;
-    display: block;
+    // display: block;
     top: 9px;
     z-index: 5;
     left: 60px;
     border-radius: 6px;
-    box-sizing: border-box;
+    // box-sizing: border-box;
     border: 1px solid rgba(0,0,0,0.4);
     padding: 3px;
     text-align: center;

--- a/src/sass/_countyCoverageMap.scss
+++ b/src/sass/_countyCoverageMap.scss
@@ -4,13 +4,13 @@ styles for component: CountyCoverage
 
 // only used by tnrisOrderTemplateDetails & HistoricalAerialTemplateDetails
 .county-coverage-component {
-  height: 80vh;
+  position: relative;
 
   #county-coverage-map {
-    position: absolute;
-    top: 165px;
-    bottom: 50px;
-    width: 100%;
+    position: relative;
+    width: auto;
+    height: 55vh;
+    top: 0;
 
     .mapboxgl-canvas {
       height: 100% !important;
@@ -30,14 +30,57 @@ styles for component: CountyCoverage
     background: $main-background;
     color: $nest-text;
     position: absolute;
-    z-index: 2;
-    top: 175px;
-    right: 5px;
-    border-radius: 3px;
+    display: block;
+    top: 9px;
+    z-index: 5;
+    left: 50px;
+    border-radius: 6px;
+    box-sizing: border-box;
     border: 1px solid rgba(0,0,0,0.4);
-    padding: 6px;
+    padding: 3px;
     text-align: center;
-    max-width: 80vw;
+    max-width: 500px;
+    // fade out notice div after 5 secs
+    -webkit-animation: fadeOut 2s forwards;
+    animation: fadeOut 2s forwards;
+    -webkit-animation-delay: 5s;
+    animation-delay: 5s;
+
+    .show-notice {
+      opacity: 1;
+    }
+
+    .hide {
+      display: none;
+    }
+
+    .visual-hide {
+      opacity: 0;
+    }
   }
+
+  // fadeOut keyframe used in coverage notice above
+  // @keyframes fadeOut {
+  //   from {
+  //     display: block;
+  //     opacity: 1;
+  //   }
+  //   to {
+  //     display: none;
+  //     opacity: 0;
+  //   }
+  // }
+
+  // fade out keyframe for -webkit used in coverage notice above
+  // @-webkit-keyframes fadeOut {
+  //   from {
+  //     display: block;
+  //     opacity: 1;
+  //   }
+  //   to {
+  //     display: none;
+  //     opacity: 0;
+  //   }
+  // }
 
 }

--- a/src/sass/_tnrisDownloadTemplateDownload.scss
+++ b/src/sass/_tnrisDownloadTemplateDownload.scss
@@ -14,8 +14,8 @@ styles for component: TnrisDownloadTemplateDownload
     color: $nest-text;
     position: absolute;
     z-index: 1;
-    top: 175px;
-    right: 10px;
+    top: 48px;
+    right: 16px;
     border-radius: 3px;
     border: 1px solid rgba(0,0,0,0.4);
 

--- a/src/sass/_tnrisDownloadTemplateDownload.scss
+++ b/src/sass/_tnrisDownloadTemplateDownload.scss
@@ -37,15 +37,11 @@ styles for component: TnrisDownloadTemplateDownload
   }
 
   #tnris-download-map {
-    // position: absolute;
     position: relative;
-    top: 0;
     width: auto;
     height: 55vh;
-    display: block;
-    // top: 165px;
-    // bottom: 50px;
-    // width: 100%;
+    top: 0;
+    margin: 8px;
 
     .mapboxgl-canvas {
       height: 100% !important;
@@ -68,9 +64,9 @@ styles for component: TnrisDownloadTemplateDownload
     color: $nest-text;
     position: absolute;
     z-index: 2;
-    bottom: 10px;
+    bottom: 8px;
     text-align: center;
-    left: 5px;
+    left: 15px;
     border-radius: 3px;
     border: 1px solid rgba(0,0,0,0.4);
     padding: 3px;
@@ -93,7 +89,7 @@ styles for component: TnrisDownloadTemplateDownload
     position: absolute;
     z-index: 2;
     top: 110px;
-    left: 8px;
+    left: 16px;
     border-radius: 5px;
     border: 1.5px solid rgba(0,0,0,0.15);
     padding: 3px;

--- a/src/sass/_tnrisDownloadTemplateDownload.scss
+++ b/src/sass/_tnrisDownloadTemplateDownload.scss
@@ -3,7 +3,7 @@ styles for component: TnrisDownloadTemplateDownload
 */
 
 .tnris-download-template-download {
-  height: 80vh;
+  position: relative;
 
   button {
     margin: 0;
@@ -37,10 +37,15 @@ styles for component: TnrisDownloadTemplateDownload
   }
 
   #tnris-download-map {
-    position: absolute;
-    top: 165px;
-    bottom: 50px;
-    width: 100%;
+    // position: absolute;
+    position: relative;
+    top: 0;
+    width: auto;
+    height: 55vh;
+    display: block;
+    // top: 165px;
+    // bottom: 50px;
+    // width: 100%;
 
     .mapboxgl-canvas {
       height: 100% !important;
@@ -63,7 +68,8 @@ styles for component: TnrisDownloadTemplateDownload
     color: $nest-text;
     position: absolute;
     z-index: 2;
-    bottom: 60px;
+    bottom: 10px;
+    text-align: center;
     left: 5px;
     border-radius: 3px;
     border: 1px solid rgba(0,0,0,0.4);
@@ -77,7 +83,7 @@ styles for component: TnrisDownloadTemplateDownload
     p {
       margin: 0;
       line-height: 20px;
-      max-width: 80vw;
+      max-width: 250px;
     }
   }
 
@@ -86,7 +92,7 @@ styles for component: TnrisDownloadTemplateDownload
     color: $nest-text;
     position: absolute;
     z-index: 2;
-    top: 270px;
+    top: 110px;
     left: 8px;
     border-radius: 5px;
     border: 1.5px solid rgba(0,0,0,0.15);

--- a/src/sass/_tnrisDownloadTemplateDownload.scss
+++ b/src/sass/_tnrisDownloadTemplateDownload.scss
@@ -41,7 +41,6 @@ styles for component: TnrisDownloadTemplateDownload
     width: auto;
     height: 55vh;
     top: 0;
-    margin: 8px;
 
     .mapboxgl-canvas {
       height: 100% !important;
@@ -64,9 +63,9 @@ styles for component: TnrisDownloadTemplateDownload
     color: $nest-text;
     position: absolute;
     z-index: 2;
-    bottom: 8px;
+    bottom: 16px;
+    left: 16px;
     text-align: center;
-    left: 15px;
     border-radius: 3px;
     border: 1px solid rgba(0,0,0,0.4);
     padding: 3px;
@@ -88,13 +87,13 @@ styles for component: TnrisDownloadTemplateDownload
     color: $nest-text;
     position: absolute;
     z-index: 2;
-    top: 110px;
+    top: 145px;
     left: 16px;
     border-radius: 5px;
     border: 1.5px solid rgba(0,0,0,0.15);
     padding: 3px;
     line-height: 12px;
-    max-width: 20vw;
+    max-width: 200px;
 
     .close-icon {
       cursor: pointer;
@@ -124,7 +123,6 @@ styles for component: TnrisDownloadTemplateDownload
     background: $main-background;
     color: $nest-text;
     padding: 35px;
-    // text-align: center;
   }
 
   .tnris-download-template-download__loading {


### PR DESCRIPTION
closes issue #209; re-org of download, order and historical templates related to images and maps. coverage and download maps replace images on details template and images go to their own tab; also new setTimeout added to both coverage and download map notes/instructions.

__dont delete this feature branch yet please__. I'm gonna cleanup some of the comments after this code is reviewed. pulling this feature branch and building locally is prob the best way to review the changes here.

outside entity templates are the same where images are on the main details page/template. no images tab was added for these cards.