### PR TITLE
Feature/expand filters

### DIFF
--- a/src/components/CollectionFilter.jsx
+++ b/src/components/CollectionFilter.jsx
@@ -98,20 +98,21 @@ export default class CollectionFilter extends React.Component {
           if (document.querySelector(hashId)) {
             document.querySelector(hashId).checked = true;
             document.querySelector(`${hashId}-label`).classList.add('filter-active');
-            // expand filter titles in tool drawer if filter is applied
-            const filterTitleList = document.querySelectorAll("#availability-title, #category-title");
-            filterTitleList.forEach(function(item) {
-              if (item.classList.contains('mdc-list-item--activated')) {
-                item.children[0].innerHTML = 'expand_less';
-                item.nextSibling.classList.remove('hide-filter-list');
-              }
-            })
           }
           return hashId;
         });
         return key;
       });
     }
+
+    // expand filter titles in tool drawer if filter is applied
+    const filterTitleList = document.querySelectorAll("#availability-title, #category-title");
+    filterTitleList.forEach(function(item) {
+      if (item.classList.contains('mdc-list-item--activated')) {
+        item.children[0].innerHTML = 'expand_less';
+        item.nextSibling.classList.remove('hide-filter-list');
+      }
+    })
   }
 
   handleOpenFilterMenu(e) {

--- a/src/components/CollectionFilter.jsx
+++ b/src/components/CollectionFilter.jsx
@@ -98,6 +98,14 @@ export default class CollectionFilter extends React.Component {
           if (document.querySelector(hashId)) {
             document.querySelector(hashId).checked = true;
             document.querySelector(`${hashId}-label`).classList.add('filter-active');
+            // expand filter titles in tool drawer if filter is applied
+            const filterTitleList = document.querySelectorAll("#availability-title, #category-title");
+            filterTitleList.forEach(function(item) {
+              if (item.classList.contains('mdc-list-item--activated')) {
+                item.children[0].innerHTML = 'expand_less';
+                item.nextSibling.classList.remove('hide-filter-list');
+              }
+            })
           }
           return hashId;
         });


### PR DESCRIPTION
this addresses the request to expand filters in the tool drawer if a filter has been applied and is present in the url. there are still plans to add mdc chips/pills as mentioned in issue #192 by @JasonKleinert, but i figured we can do both.

closes issue #192

__note__: when testing for this feature, i discovered a bug (see issue #212)