### PR TITLE
Feature/services filter

### DIFF
--- a/src/components/CollectionFilter.jsx
+++ b/src/components/CollectionFilter.jsx
@@ -212,39 +212,6 @@ export default class CollectionFilter extends React.Component {
                      id={`${choice}-expansion-icon`}>expand_more</i>
                 </div>
                   <ul className='mdc-list hide-filter-list' id={`${choice}-list`}>
-                    {/* begin fudge factory; here is where we fudge in the new wms service filter */}
-                    {
-                      `${choice}` === 'availability' ? (
-                        <li className='mdc-list-item'>
-                          <div className='mdc-form-field'>
-                            <div className='mdc-checkbox'>
-                              <input type='checkbox'
-                                     className='mdc-checkbox__native-control'
-                                     id='WMS_Service'
-                                     name='availability'
-                                     value='WMS_Service'
-                                     onChange={e => this.handleSetFilter(e.target)}
-                                     onKeyDown={(e) => this.handleKeySetFilter(e)}/>
-                              <div className='mdc-checkbox__background'>
-                                <svg className='mdc-checkbox__checkmark'
-                                     viewBox='0 0 24 24'>
-                                  <path className='mdc-checkbox__checkmark-path'
-                                        fill='none'
-                                        d='M1.73,12.91 8.1,19.28 22.79,4.59'/>
-                                </svg>
-                                <div className='mdc-checkbox__mixedmark'></div>
-                              </div>
-                            </div>
-                            <label id='WMS_Service-label'
-                                   htmlFor='WMS_Service'>
-                                   WMS Service
-                           </label>
-                          </div>
-                        </li>
-                      ) : ""
-                    }
-                    {/* end fudge factory */}
-
                     {
                       this.props.collectionFilterChoices[choice].map((choiceValue, i) =>{
                         const labelValue = choiceValue.replace(/_/g, ' ');

--- a/src/components/CollectionFilter.jsx
+++ b/src/components/CollectionFilter.jsx
@@ -212,10 +212,44 @@ export default class CollectionFilter extends React.Component {
                      id={`${choice}-expansion-icon`}>expand_more</i>
                 </div>
                   <ul className='mdc-list hide-filter-list' id={`${choice}-list`}>
+                    {/* begin fudge factory; here is where we fudge in the new wms service filter */}
+                    {
+                      `${choice}` === 'availability' ? (
+                        <li className='mdc-list-item'>
+                          <div className='mdc-form-field'>
+                            <div className='mdc-checkbox'>
+                              <input type='checkbox'
+                                     className='mdc-checkbox__native-control'
+                                     id='WMS_Service'
+                                     name='availability'
+                                     value='WMS_Service'
+                                     onChange={e => this.handleSetFilter(e.target)}
+                                     onKeyDown={(e) => this.handleKeySetFilter(e)}/>
+                              <div className='mdc-checkbox__background'>
+                                <svg className='mdc-checkbox__checkmark'
+                                     viewBox='0 0 24 24'>
+                                  <path className='mdc-checkbox__checkmark-path'
+                                        fill='none'
+                                        d='M1.73,12.91 8.1,19.28 22.79,4.59'/>
+                                </svg>
+                                <div className='mdc-checkbox__mixedmark'></div>
+                              </div>
+                            </div>
+                            <label id='WMS_Service-label'
+                                   htmlFor='WMS_Service'>
+                                   WMS Service
+                           </label>
+                          </div>
+                        </li>
+                      ) : ""
+                    }
+                    {/* end fudge factory */}
+
                     {
                       this.props.collectionFilterChoices[choice].map((choiceValue, i) =>{
                         const labelValue = choiceValue.replace(/_/g, ' ');
-                        return (<li className='mdc-list-item'
+                        return (
+                          <li className='mdc-list-item'
                                     key={choiceValue}>
                           <div className='mdc-form-field'>
                             <div className='mdc-checkbox'>
@@ -242,7 +276,8 @@ export default class CollectionFilter extends React.Component {
                            </label>
                           </div>
                         </li>);
-                    })}
+                      })
+                    }
                   </ul>
               </li>
             )

--- a/src/selectors/collectionSelectors.js
+++ b/src/selectors/collectionSelectors.js
@@ -253,9 +253,10 @@ export const getFilteredCollections = createSelector(
       // pass through those filters. The multiFilteredCollectionIds account
       // for cross filtering scenarios. The exception to this rule is the fudged
       // WMS_Service filter which is handled specifically.
-      // console.log('multiFilteredCollectionIds:', multiFilteredCollectionIds)
-      // console.log('filteredCollectionIds:', filteredCollectionIds)
-      // console.log(filteredCollectionIds.includes('0b6b75dc-c163-4199-a045-b2e5350c75df'));
+      console.log('multiFilteredCollectionIds:', multiFilteredCollectionIds)
+      console.log('filteredCollectionIds:', filteredCollectionIds)
+      console.log(filteredCollectionIds.includes('0b6b75dc-c163-4199-a045-b2e5350c75df'));
+      
       return Object.keys(filters).length > 1 ?
         filters['availability'].includes('WMS_Service') ? filteredCollectionIds : multiFilteredCollectionIds
         : filteredCollectionIds;

--- a/src/selectors/collectionSelectors.js
+++ b/src/selectors/collectionSelectors.js
@@ -121,7 +121,8 @@ export const getCollectionFilterChoices = createSelector(
     // The key must match a property of the collections object and
     // the value is an empty array.
     const collectionFilterChoices = {
-      availability: [],
+      // hard code in new filter by wms service option
+      availability: ['WMS_Service'],
       category: []
     };
     // If collections are in ready the state, continue setting the value arrays in the
@@ -203,12 +204,13 @@ export const getFilteredCollections = createSelector(
 
       let filteredCollectionIds = [];
       let multiFilteredCollectionIds = [];
+
       collectionIds.map(collectionId => {
         for (let key in filters) {
           if (filters.hasOwnProperty(key)) {
-            // need to check if collection has a
-            // value for the key so it can be split
             if (collections[collectionId][key]) {
+              // need to check if collection has a
+              // value for the key so it can be split
               let collectionPropertyValues = collections[collectionId][key].split(',');
               collectionPropertyValues.map(propertyValue => {
                 if (filters[key].indexOf(propertyValue) >= 0) {
@@ -223,6 +225,11 @@ export const getFilteredCollections = createSelector(
                       multiFilteredCollectionIds.push(collectionId);
                     }
                   }
+                }
+                // special handling for fudged WMS_Service filtering
+                else if (collections[collectionId][key] === 'Download' && collections[collectionId].wms_link !== null) {
+                  console.log(filters[key])
+                  filteredCollectionIds.push(collectionId)
                 }
                 return propertyValue;
               })

--- a/src/selectors/collectionSelectors.js
+++ b/src/selectors/collectionSelectors.js
@@ -122,7 +122,7 @@ export const getCollectionFilterChoices = createSelector(
     // the value is an empty array.
     const collectionFilterChoices = {
       // hard code in new filter by wms service option
-      availability: ['WMS_Service'],
+      availability: [],
       category: []
     };
     // If collections are in ready the state, continue setting the value arrays in the
@@ -209,6 +209,23 @@ export const getFilteredCollections = createSelector(
         for (let key in filters) {
           if (filters.hasOwnProperty(key)) {
             if (collections[collectionId][key]) {
+              // fudge factory ---> fudges in a wms service filter
+              // check if availability-WMS_Service filter is present, then check if collection has a valid wms link
+              if (filters['availability'].includes('WMS_Service') && collections[collectionId].wms_link) {
+                if (filteredCollectionIds.indexOf(collectionId) < 0) {
+                  // set collection_ids that pass the filter conditions
+                  // into this array
+                  filteredCollectionIds.push(collectionId);
+                } else {
+                  // set any duplicate collection_ids from the conditional
+                  // above into this array to account for cross filtering
+                  if (multiFilteredCollectionIds.indexOf(collectionId) < 0) {
+                    multiFilteredCollectionIds.push(collectionId);
+                  }
+                }
+              }
+              // end fudge factory; now proceed to normal operations
+
               // need to check if collection has a
               // value for the key so it can be split
               let collectionPropertyValues = collections[collectionId][key].split(',');
@@ -225,11 +242,6 @@ export const getFilteredCollections = createSelector(
                       multiFilteredCollectionIds.push(collectionId);
                     }
                   }
-                }
-                // special handling for fudged WMS_Service filtering
-                else if (collections[collectionId][key] === 'Download' && collections[collectionId].wms_link !== null) {
-                  console.log(filters[key])
-                  filteredCollectionIds.push(collectionId)
                 }
                 return propertyValue;
               })

--- a/src/selectors/collectionSelectors.js
+++ b/src/selectors/collectionSelectors.js
@@ -210,17 +210,16 @@ export const getFilteredCollections = createSelector(
             if (collections[collectionId][key]) {
               // fudge factory ---> fudges in a wms service filter
               // check if availability-WMS_Service filter is present, then check if collection has a valid wms link
-              if (filters['availability'].includes('WMS_Service') && collections[collectionId].wms_link) {
+              if (filters['availability'] && filters['availability'].includes('WMS_Service') && collections[collectionId].wms_link) {
                 if (filteredCollectionIds.indexOf(collectionId) < 0) {
                   // set collection_ids that pass the filter conditions
                   // into this array
                   filteredCollectionIds.push(collectionId);
-                } else {
-                  // set any duplicate collection_ids from the conditional
-                  // above into this array to account for cross filtering
-                  if (multiFilteredCollectionIds.indexOf(collectionId) < 0) {
-                    multiFilteredCollectionIds.push(collectionId);
-                  }
+                }
+                // set any duplicate collection_ids from the conditional
+                // above into this array to account for cross filtering
+                else if (multiFilteredCollectionIds.indexOf(collectionId) < 0) {
+                  multiFilteredCollectionIds.push(collectionId);
                 }
               }
               // end fudge factory; now proceed to normal operations
@@ -234,7 +233,8 @@ export const getFilteredCollections = createSelector(
                     // set collection_ids that pass the filter conditions
                     // into this array
                     filteredCollectionIds.push(collectionId);
-                  } else {
+                  }
+                  else {
                     // set any duplicate collection_ids from the conditional
                     // above into this array to account for cross filtering
                     if (multiFilteredCollectionIds.indexOf(collectionId) < 0) {
@@ -251,8 +251,14 @@ export const getFilteredCollections = createSelector(
       })
       // when 1 or more filters are set, return the collection_ids that
       // pass through those filters. The multiFilteredCollectionIds account
-      // for cross filtering scenarios.
-      return Object.keys(filters).length > 1 ? multiFilteredCollectionIds : filteredCollectionIds;
+      // for cross filtering scenarios. The exception to this rule is the fudged
+      // WMS_Service filter which is handled specifically.
+      // console.log('multiFilteredCollectionIds:', multiFilteredCollectionIds)
+      // console.log('filteredCollectionIds:', filteredCollectionIds)
+      // console.log(filteredCollectionIds.includes('0b6b75dc-c163-4199-a045-b2e5350c75df'));
+      return Object.keys(filters).length > 1 ?
+        filters['availability'].includes('WMS_Service') ? filteredCollectionIds : multiFilteredCollectionIds
+        : filteredCollectionIds;
     }
   }
 );

--- a/src/selectors/collectionSelectors.js
+++ b/src/selectors/collectionSelectors.js
@@ -121,7 +121,6 @@ export const getCollectionFilterChoices = createSelector(
     // The key must match a property of the collections object and
     // the value is an empty array.
     const collectionFilterChoices = {
-      // hard code in new filter by wms service option
       availability: [],
       category: []
     };

--- a/src/selectors/collectionSelectors.js
+++ b/src/selectors/collectionSelectors.js
@@ -38,6 +38,24 @@ export const getAllCollectionIds = createSelector(
   }
 );
 
+export const getServiceIds = createSelector(
+  [ getCollections ],
+  (collections) => {
+    let serviceIds = [];
+    if (collections.result) {
+      collections.result.map(collectionId => {
+        if (serviceIds.indexOf(collectionId) < 0) {
+          if (collections.entities.collectionsById[collectionId].wms_link) {
+            serviceIds.push(collectionId);
+          }
+        }
+        return collectionId;
+      })
+    }
+    return serviceIds;
+  }
+);
+
 export const getSearchIndex = createSelector(
   [ getCollections ],
   (collections) => {
@@ -121,7 +139,7 @@ export const getCollectionFilterChoices = createSelector(
     // The key must match a property of the collections object and
     // the value is an empty array.
     const collectionFilterChoices = {
-      availability: [],
+      availability: ['WMS_Service'],
       category: []
     };
     // If collections are in ready the state, continue setting the value arrays in the
@@ -191,8 +209,8 @@ export const getCollectionTimesliderRange = createSelector(
 // through the filters. If no filters are set, or on initial page load,
 // returns an array of all collection_ids available in the catalog.
 export const getFilteredCollections = createSelector(
-  [ getAllCollections, getAllCollectionIds, getFilters ],
-  (collections, collectionIds, filters) => {
+  [ getAllCollections, getAllCollectionIds, getFilters, getServiceIds ],
+  (collections, collectionIds, filters, serviceIds) => {
     // Check if collections are ready in the state
     if (collections) {
       // when no filters are set, return all collection_ids to make all
@@ -204,26 +222,16 @@ export const getFilteredCollections = createSelector(
       let filteredCollectionIds = [];
       let multiFilteredCollectionIds = [];
 
+      // check if wms service filter is checked first then set
+      // filteredCollectionIds equal to serviceIds array (from getServiceIds above)
+      if (filters['availability'] && filters['availability'].includes('WMS_Service')) {
+        filteredCollectionIds = [...serviceIds];
+      }
+
       collectionIds.map(collectionId => {
         for (let key in filters) {
           if (filters.hasOwnProperty(key)) {
             if (collections[collectionId][key]) {
-              // fudge factory ---> fudges in a wms service filter
-              // check if availability-WMS_Service filter is present, then check if collection has a valid wms link
-              if (filters['availability'] && filters['availability'].includes('WMS_Service') && collections[collectionId].wms_link) {
-                if (filteredCollectionIds.indexOf(collectionId) < 0) {
-                  // set collection_ids that pass the filter conditions
-                  // into this array
-                  filteredCollectionIds.push(collectionId);
-                }
-                // set any duplicate collection_ids from the conditional
-                // above into this array to account for cross filtering
-                else if (multiFilteredCollectionIds.indexOf(collectionId) < 0) {
-                  multiFilteredCollectionIds.push(collectionId);
-                }
-              }
-              // end fudge factory; now proceed to normal operations
-
               // need to check if collection has a
               // value for the key so it can be split
               let collectionPropertyValues = collections[collectionId][key].split(',');
@@ -253,13 +261,7 @@ export const getFilteredCollections = createSelector(
       // pass through those filters. The multiFilteredCollectionIds account
       // for cross filtering scenarios. The exception to this rule is the fudged
       // WMS_Service filter which is handled specifically.
-      console.log('multiFilteredCollectionIds:', multiFilteredCollectionIds)
-      console.log('filteredCollectionIds:', filteredCollectionIds)
-      console.log(filteredCollectionIds.includes('0b6b75dc-c163-4199-a045-b2e5350c75df'));
-      
-      return Object.keys(filters).length > 1 ?
-        filters['availability'].includes('WMS_Service') ? filteredCollectionIds : multiFilteredCollectionIds
-        : filteredCollectionIds;
+      return Object.keys(filters).length > 1 ? multiFilteredCollectionIds : filteredCollectionIds;
     }
   }
 );


### PR DESCRIPTION
__what is this?__
this is a new **Availability - WMS_Service collection filter** in the tool drawer. 

__methodology__
I manually fudged in the input checkbox html in the collectionFilter component feeding it the same capabilities/functions as the other automatically created filter input checkboxes below this one. then in the collectionSelectors, the getFilteredCollections method handles the logic to specifically check for the 'WMS_Service' filter being set first, and then checks for all collection ids with a valid wms_link property before adding those collection ids to the filteredCollectionIds or multiFilteredCollectionIds array.

i need this one tested out pretty good before we merge it. i've run through it a couple dozen times and it seems to behave properly but i want to make sure its solid.

there is probably a better way to do this and i'm open to suggestions for ways to re-factor or change this functionality. its seems to work pretty good though I think. take a look and let me know what yall think. we can push new commits and change this if you guys think we should. whatever works best.

thanks.