### PR TITLE
be gone header & collection details re-org

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6973,9 +6973,9 @@
       "integrity": "sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ=="
     },
     "handlebars": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.0.tgz",
-      "integrity": "sha512-xkRtOt3/3DzTKMOt3xahj2M/EqNhY988T+imYSlMgs5fVhLN2fmKVVj0LtEGmb+3UUYV5Qmm1052Mm3dIQxOvw==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.2.tgz",
+      "integrity": "sha512-29Zxv/cynYB7mkT1rVWQnV7mGX6v7H/miQ6dbEpYTKq5eJBN7PsRB+ViYJlcT6JINTSu4dVB9kOqEun78h6Exg==",
       "requires": {
         "neo-async": "^2.6.0",
         "optimist": "^0.6.1",

--- a/src/components/Catalog.jsx
+++ b/src/components/Catalog.jsx
@@ -313,6 +313,9 @@ export default class Catalog extends React.Component {
       return this.loadingMessage;
     }
 
+    console.log(this.props.view)
+    const viewClass = this.props.view === 'catalog' ? 'catalog-view-container' : 'other-view-container';
+
     return (
       <div className="catalog-component">
 
@@ -320,7 +323,7 @@ export default class Catalog extends React.Component {
 
         <HeaderContainer handleToolDrawerDisplay={this.handleToolDrawerDisplay} />
 
-        <div className='view-container'>
+        <div className={viewClass}>
           <Switch>
             <Route path='/collection/:collectionId' exact render={(props) => this.handleShowCollectionView()} />
             <Route path='/catalog/:filters' exact render={(props) => this.setCatalogView()} />

--- a/src/components/Catalog.jsx
+++ b/src/components/Catalog.jsx
@@ -313,7 +313,6 @@ export default class Catalog extends React.Component {
       return this.loadingMessage;
     }
 
-    console.log(this.props.view)
     const viewClass = this.props.view === 'catalog' ? 'catalog-view-container' : 'other-view-container';
 
     return (

--- a/src/components/CollectionFilterMapView.jsx
+++ b/src/components/CollectionFilterMapView.jsx
@@ -4,6 +4,8 @@ import {MDCSelect} from '@material/select';
 
 import CollectionFilterMapContainer from '../containers/CollectionFilterMapContainer';
 
+import BackButtonContainer from '../containers/BackButtonContainer'
+
 // the carto core api is a CDN in the app template HTML (not available as NPM package)
 // so we create a constant to represent it so it's available to the component
 const cartodb = window.cartodb;
@@ -123,12 +125,9 @@ export default class CollectionFilterMapView extends React.Component {
                 </div>
               </div>
             </div>
-            <button
-              className="close-shopping-cart mdc-icon-button material-icons"
-              onClick={this.handleBack}
-              title="Close geography filter">
-              close
-            </button>
+
+            <BackButtonContainer />
+
           </section>
         </div>
         <CollectionFilterMapContainer />

--- a/src/components/CollectionFilterMapView.jsx
+++ b/src/components/CollectionFilterMapView.jsx
@@ -16,7 +16,6 @@ export default class CollectionFilterMapView extends React.Component {
     this.state = {
       countyNames: []
     }
-    this.handleBack = this.handleBack.bind(this);
     this.getAreaTypeNames = this.getAreaTypeNames.bind(this);
     this.handleChangeCountyName = this.handleChangeCountyName.bind(this);
   }
@@ -46,11 +45,6 @@ export default class CollectionFilterMapView extends React.Component {
     } else {
       countySelect.disabled = false;
     }
-  }
-
-  handleBack() {
-    this.props.setViewCatalog();
-    this.props.setUrl(this.props.catalogFilterUrl);
   }
 
   getAreaTypeNames() {

--- a/src/components/DialogTemplateListItems/BackButton.jsx
+++ b/src/components/DialogTemplateListItems/BackButton.jsx
@@ -1,0 +1,25 @@
+import React from 'react'
+
+export default class BackButton extends React.Component {
+
+  constructor(props) {
+      super(props);
+      this.handleBack = this.handleBack.bind(this);
+  }
+
+  handleBack() {
+    this.props.setViewCatalog();
+    this.props.setUrl(this.props.previousUrl);
+  }
+
+  render() {
+    return (
+      <button
+        className="mdc-icon-button material-icons close-collection"
+        onClick={this.handleBack}
+        title="Close this view">
+          close
+      </button>
+    )
+  }
+}

--- a/src/components/DialogTemplateListItems/BackButton.jsx
+++ b/src/components/DialogTemplateListItems/BackButton.jsx
@@ -13,8 +13,8 @@ export default class BackButton extends React.Component {
     if (this.props.view === 'geoFilter') {
       this.props.setViewCatalog();
       this.props.setUrl(this.props.catalogFilterUrl);
-      // this next condition is for when deving locally
-      // if update to code, app refreshes and previousUrl becomes current url;
+      // this next condition is for when developing locally.
+      // on update to code, app refreshes and previousUrl becomes current url;
       // override this by hard setting the url to root
     } else if (this.props.previousUrl === window.location.pathname) {
       this.props.setViewCatalog();

--- a/src/components/DialogTemplateListItems/BackButton.jsx
+++ b/src/components/DialogTemplateListItems/BackButton.jsx
@@ -8,11 +8,26 @@ export default class BackButton extends React.Component {
   }
 
   handleBack() {
-    this.props.setViewCatalog();
-    this.props.setUrl(this.props.previousUrl);
+    // special handling for geoFilter due to clear filter functionality inside
+    // the geoFilter which updages the url and conflicts with previousUrl
+    if (this.props.view === 'geoFilter') {
+      this.props.setViewCatalog();
+      this.props.setUrl(this.props.catalogFilterUrl);
+      // this next condition is for when deving locally
+      // if update to code, app refreshes and previousUrl becomes current url;
+      // override this by hard setting the url to root
+    } else if (this.props.previousUrl === window.location.pathname) {
+      this.props.setViewCatalog();
+      this.props.setUrl('/')
+      // all other conditions, setViewCatalog and use previousUrl
+    } else {
+      this.props.setViewCatalog();
+      this.props.setUrl(this.props.previousUrl);
+    }
   }
 
   render() {
+
     return (
       <button
         className="mdc-icon-button material-icons close-collection"

--- a/src/components/DialogTemplateListItems/CountyCoverage.jsx
+++ b/src/components/DialogTemplateListItems/CountyCoverage.jsx
@@ -39,52 +39,6 @@ export default class CountyCoverage extends React.Component {
     if (!document.querySelector('.mapboxgl-ctrl-fullscreen')) {
       map.addControl(new mapboxgl.FullscreenControl(), 'top-right');
     }
-    // class for custom map controls; not currently being used but might be useful in future
-    // *** event handler is commented out but might be useful for future new controls ***
-    // class ButtonControl {
-    //   constructor({
-    //     id = "",
-    //     className = "",
-    //     title = ""
-    //     // eventHandler = ""
-    //   }) {
-    //     this._id = id;
-    //     this._className = className;
-    //     this._title = title;
-    //     // this._eventHandler = eventHandler;
-    //   }
-    //   onAdd(map){
-    //     this._btn = document.createElement("button");
-    //     this._btn.id = this._id;
-    //     this._btn.className = this._className;
-    //     this._btn.type = "button";
-    //     this._btn.title = this._title;
-    //     // this._btn.onclick = this._eventHandler;
-    //
-    //     this._container = document.createElement("div");
-    //     this._container.className = "mapboxgl-ctrl mapboxgl-ctrl-group";
-    //     this._container.appendChild(this._btn);
-    //
-    //     return this._container;
-    //   }
-    //   onRemove() {
-    //     this._container.parentNode.removeChild(this._container);
-    //   }
-    // }
-    // event handlers for custom controls
-    // const notice = () => {
-    //   const noticeBtn = document.querySelector('#county-coverage');
-    //   noticeBtn.classList.contains('close') ? noticeBtn.classList.remove('close') : noticeBtn.classList.add('close');
-    // }
-    // custom control variables
-    // const ctrlNotice = new ButtonControl({
-    //   id: 'county-coverage',
-    //   className: 'coverage-notice',
-    //   title: 'County Coverage Notice',
-    //   eventHandler: notice
-    // });
-    // add custom controls to map
-    // map.addControl(ctrlNotice, 'top-left');
 
     // add tooltips for map controls
     document.querySelector('.mapboxgl-ctrl-zoom-in').setAttribute('title', 'Zoom In');

--- a/src/components/DialogTemplateListItems/Description.jsx
+++ b/src/components/DialogTemplateListItems/Description.jsx
@@ -55,14 +55,15 @@ export default class Description extends React.Component {
   }
 
   setTextFade() {
-    const height = this.refs.descript.clientHeight;
-    height < 300 ? this.setState({
-      descriptClass:'',
+    let descriptHt = this.refs.descript.clientHeight;
+
+    descriptHt < 400 ? this.setState({
+      descriptClass: '',
       showButton: false
     }) : this.setState({
-      descriptClass:'fade-text',
-      showButton:true
-    })
+      descriptClass: 'fade-text',
+      showButton: true
+    });
   }
 
   toggleText() {
@@ -84,11 +85,15 @@ export default class Description extends React.Component {
   render() {
 
     const createMarkup = () => {
-      return {__html: this.state.wikiExtract};
+      if (this.state.wikiExtract) {
+        return {__html: this.state.wikiExtract};
+      }
     }
 
     const createMarkupDesc = () => {
-      return {__html: this.props.collection.description};
+      if (this.props.collection.description) {
+        return {__html: this.props.collection.description};
+      }
     }
 
     const showButton = this.state.showButton ?  (

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -99,6 +99,7 @@ export default class Header extends React.Component {
     ) : '';
 
     const filters = ['filter', 'geo', 'sort', 'range'];
+    
     const toolDrawerNotification = filters.map(x => this.props.location.pathname.includes(x) ?
       (<NotificationBadge key={x} label='!' count={1} frameLength={30}/>) : '');
 
@@ -127,65 +128,93 @@ export default class Header extends React.Component {
                 view_comfy
             </button>) : '';
 
-    return (
-        <header
-          className={`header-component mdc-top-app-bar mdc-top-app-bar--fixed`}
-          id="master-header">
-          <div className="header-title mdc-top-app-bar__row">
-            <section className="mdc-top-app-bar__section mdc-top-app-bar__section--align-start">
-              <a href="https://tnris.org">
-                <img className="tnris-logo" src={tnrisLogo} alt="TNRIS Logo" title="tnris.org" />
-              </a>
-              <a
-                className='header-title__tnris title-size'
-                href="https://tnris.org/"
-                tabIndex="0"
-                title="tnris.org">
-                  {this.state.tnrisTitle}
-              </a>
-            </section>
-            <section className="mdc-top-app-bar__section mdc-top-app-bar__section--align-end">
-              <a className='header-title__twdb title-size' href="http://www.twdb.texas.gov/" tabIndex="0">
-                {this.state.twdbTitle}
-              </a>
-            </section>
-          </div>
-          <div className={`header-nav mdc-top-app-bar__row ${drawerStatusClass}`}>
-            <section className="mdc-top-app-bar__section mdc-top-app-bar__section--align-start" role="toolbar">
-              {appTitle}
-            </section>
-            <section className="mdc-top-app-bar__section mdc-top-app-bar__section--align-end" role="toolbar">
-              <CollectionSearcherContainer />
-              {this.props.orders && Object.keys(this.props.orders).length !== 0 && this.props.view !== 'geoFilter' ?
-                 <div className="shopping-cart-icon nav-button">
-                   {shoppingCartCountBadge}
+    const header = this.props.view === 'catalog' ? (
+      <header
+        className={`header-component mdc-top-app-bar mdc-top-app-bar--fixed`}
+        id="master-header">
+        <div className="header-title mdc-top-app-bar__row">
+          <section className="mdc-top-app-bar__section mdc-top-app-bar__section--align-start">
+            <a href="https://tnris.org">
+              <img className="tnris-logo" src={tnrisLogo} alt="TNRIS Logo" title="tnris.org" />
+            </a>
+            <a
+              className='header-title__tnris title-size'
+              href="https://tnris.org/"
+              tabIndex="0"
+              title="tnris.org">
+                {this.state.tnrisTitle}
+            </a>
+          </section>
+          <section className="mdc-top-app-bar__section mdc-top-app-bar__section--align-end">
+            <a className='header-title__twdb title-size' href="http://www.twdb.texas.gov/" tabIndex="0">
+              {this.state.twdbTitle}
+            </a>
+          </section>
+        </div>
+        <div className={`header-nav mdc-top-app-bar__row ${drawerStatusClass}`}>
+          <section className="mdc-top-app-bar__section mdc-top-app-bar__section--align-start" role="toolbar">
+            {appTitle}
+          </section>
+          <section className="mdc-top-app-bar__section mdc-top-app-bar__section--align-end" role="toolbar">
+            <CollectionSearcherContainer />
+            {this.props.orders && Object.keys(this.props.orders).length !== 0 && this.props.view !== 'geoFilter' ?
+               <div className="shopping-cart-icon nav-button">
+                 {shoppingCartCountBadge}
+                <button
+                  onClick={this.handleOrderCartView}
+                  onKeyDown={(e) => this.handleKeyPress(e, 'cart')}
+                  className="material-icons mdc-top-app-bar__navigation-icon"
+                  title="View shopping cart"
+                  tabIndex="3">
+                  shopping_cart
+                </button>
+              </div> : ''}
+              {this.props.view === 'catalog' ?
+                <div className="tool-drawer-icon nav-button">
+                  {toolDrawerNotification}
                   <button
-                    onClick={this.handleOrderCartView}
-                    onKeyDown={(e) => this.handleKeyPress(e, 'cart')}
+                    onClick={this.props.handleToolDrawerDisplay}
+                    onKeyDown={(e) => this.handleKeyPress(e, 'toolDrawer')}
                     className="material-icons mdc-top-app-bar__navigation-icon"
-                    title="View shopping cart"
+                    id="tools"
+                    title={this.props.toolDrawerStatus === 'closed' ? 'Open tool drawer' : 'Close tool drawer'}
                     tabIndex="3">
-                    shopping_cart
+                      tune
                   </button>
                 </div> : ''}
-                {this.props.view === 'catalog' ?
-                  <div className="tool-drawer-icon nav-button">
-                    {toolDrawerNotification}
-                    <button
-                      onClick={this.props.handleToolDrawerDisplay}
-                      onKeyDown={(e) => this.handleKeyPress(e, 'toolDrawer')}
-                      className="material-icons mdc-top-app-bar__navigation-icon"
-                      id="tools"
-                      title={this.props.toolDrawerStatus === 'closed' ? 'Open tool drawer' : 'Close tool drawer'}
-                      tabIndex="3">
-                      {/*{this.props.toolDrawerVariant === 'dismissible' ?
-                        this.props.toolDrawerStatus === 'closed' ? 'menu' : 'tune' : 'tune'}*/}
-                        tune
-                    </button>
-                  </div> : ''}
-            </section>
-          </div>
-        </header>
+          </section>
+        </div>
+      </header>
+    ) : (
+      <header
+        className={`header-component mdc-top-app-bar mdc-top-app-bar--fixed`}
+        id="master-header">
+        <div className="header-title mdc-top-app-bar__row">
+          <section className="mdc-top-app-bar__section mdc-top-app-bar__section--align-start">
+            <a href="https://tnris.org">
+              <img className="tnris-logo" src={tnrisLogo} alt="TNRIS Logo" title="tnris.org" />
+            </a>
+            <a
+              className='header-title__tnris title-size'
+              href="https://tnris.org/"
+              tabIndex="0"
+              title="tnris.org">
+                {this.state.tnrisTitle}
+            </a>
+          </section>
+          <section className="mdc-top-app-bar__section mdc-top-app-bar__section--align-end">
+            <a className='header-title__twdb title-size' href="http://www.twdb.texas.gov/" tabIndex="0">
+              {this.state.twdbTitle}
+            </a>
+          </section>
+        </div>
+      </header>
     );
+
+    return (
+      <div>
+        {header}
+      </div>
+    )
   }
 }

--- a/src/components/HistoricalAerialTemplate/HistoricalAerialTemplate.jsx
+++ b/src/components/HistoricalAerialTemplate/HistoricalAerialTemplate.jsx
@@ -66,7 +66,8 @@ export default class HistoricalAerialTemplate extends React.Component {
         showComponent = (
           <Images
             thumbnail={this.props.collection.thumbnail_image}
-            images={this.props.collection.images} />
+            images={this.props.collection.images}
+            template={this.props.collection.template} />
         )
         break;
       case 'order':

--- a/src/components/HistoricalAerialTemplate/HistoricalAerialTemplate.jsx
+++ b/src/components/HistoricalAerialTemplate/HistoricalAerialTemplate.jsx
@@ -173,8 +173,6 @@ export default class HistoricalAerialTemplate extends React.Component {
                         <span className="mdc-tab__ripple"></span>
                       </button>
 
-                      <BackButtonContainer />
-
                     </div>
                   </div>
                 </div>
@@ -210,10 +208,10 @@ export default class HistoricalAerialTemplate extends React.Component {
                     </div>
                   </nav>
                 </div>
-
-                <BackButtonContainer />
-                
               </div>
+
+              <BackButtonContainer />
+
             </section>
           </div>
         </header>

--- a/src/components/HistoricalAerialTemplate/HistoricalAerialTemplate.jsx
+++ b/src/components/HistoricalAerialTemplate/HistoricalAerialTemplate.jsx
@@ -9,6 +9,7 @@ import Images from '../Images'
 
 import OrderTnrisDataFormContainer from '../../containers/OrderTnrisDataFormContainer'
 import ContactContainer from '../../containers/ContactContainer'
+import BackButtonContainer from '../../containers/BackButtonContainer'
 
 export default class HistoricalAerialTemplate extends React.Component {
   constructor(props) {
@@ -172,6 +173,8 @@ export default class HistoricalAerialTemplate extends React.Component {
                         <span className="mdc-tab__ripple"></span>
                       </button>
 
+                      <BackButtonContainer />
+
                     </div>
                   </div>
                 </div>
@@ -207,6 +210,9 @@ export default class HistoricalAerialTemplate extends React.Component {
                     </div>
                   </nav>
                 </div>
+
+                <BackButtonContainer />
+                
               </div>
             </section>
           </div>

--- a/src/components/HistoricalAerialTemplate/HistoricalAerialTemplateDetails.jsx
+++ b/src/components/HistoricalAerialTemplate/HistoricalAerialTemplateDetails.jsx
@@ -95,24 +95,20 @@ export default class TnrisDownloadTemplateDetails extends React.Component {
                                {archiveAbout}
                                {productsCard}
                                {ls4LinksCard}
+                               {sourceCitation}
                                <ShareButtons />
                              </div>
                              <div className='mdc-layout-grid__cell mdc-layout-grid__cell--span-8'>
-                               {/*{imageCarousel}*/}
                                {countyCoverage}
                                <div className="mdc-layout-grid__inner">
-                                 <div className='mdc-layout-grid__cell mdc-layout-grid__cell--span-8'>
+                                 <div className='mdc-layout-grid__cell mdc-layout-grid__cell--span-12'>
                                    <Description collection={collectionObj} />
-                                 </div>
-                                 <div className='mdc-layout-grid__cell mdc-layout-grid__cell--span-4'>
-                                   {sourceCitation}
                                  </div>
                                </div>
                              </div>
                            </div>) : (
                            <div className="mdc-layout-grid__inner">
                              <div className='mdc-layout-grid__cell mdc-layout-grid__cell--span-12'>
-                               {/*{imageCarousel}*/}
                                {countyCoverage}
                                <Metadata collection={this.props.collection} />
                                <Description collection={collectionObj} />

--- a/src/components/Images.jsx
+++ b/src/components/Images.jsx
@@ -3,18 +3,24 @@ import React from 'react'
 import {Carousel} from 'react-responsive-carousel'
 
 export default class Images extends React.Component {
-  render() {
+
+  componentDidMount() {
     window.scrollTo(0,0);
-    
+  }
+
+  render() {
+
     let carousel_images = this.props.images ? this.props.images.split(',') : "";
     carousel_images = carousel_images.filter(item => item !== this.props.thumbnail);
     carousel_images.unshift(this.props.thumbnail);
 
     const multiImage = carousel_images.length > 1 ? true : false;
 
+    const padClass = this.props.template === 'outside-entity' ? '' : 'pad-class';
+
     return (
-      <div className="tnris-template-images">
-        <div className="image-container">
+      <div className='tnris-template-images'>
+        <div className={`image-container ${padClass}`}>
           <Carousel
             autoPlay={multiImage}
             infiniteLoop={multiImage}

--- a/src/components/OrderCartView.jsx
+++ b/src/components/OrderCartView.jsx
@@ -1,29 +1,11 @@
 import React from 'react'
 import OrderCartContainer from '../containers/OrderCartContainer'
+import BackButtonContainer from '../containers/BackButtonContainer'
 
 class OrderCartView extends React.Component {
-  constructor() {
-    super();
-    this.handleBack = this.handleBack.bind(this);
-  }
 
   componentDidMount() {
     window.scrollTo(0,0);
-  }
-
-  handleBack() {
-    if (this.props.previousUrl.includes('/catalog/')) {
-      this.props.setViewCatalog();
-      this.props.setUrl(this.props.previousUrl);
-    } else if (this.props.previousUrl.includes('/collection/')) {
-        const collectionUuid = this.props.previousUrl.replace('/collection/', '');
-        this.props.setViewCollection();
-        this.props.selectCollection(collectionUuid);
-        this.props.setUrl(this.props.previousUrl);
-    } else {
-        this.props.setViewCatalog();
-        this.props.setUrl(this.props.previousUrl);
-    }
   }
 
   render() {
@@ -36,12 +18,7 @@ class OrderCartView extends React.Component {
             </span>
           </section>
           <section className="mdc-top-app-bar__section mdc-top-app-bar__section--align-end">
-            <button
-              className="close-shopping-cart mdc-icon-button material-icons"
-              onClick={this.handleBack}
-              title="Close shopping cart">
-              close
-            </button>
+            <BackButtonContainer />
           </section>
         </div>
         <OrderCartContainer />

--- a/src/components/TnrisDownloadTemplate/TnrisDownloadTemplate.jsx
+++ b/src/components/TnrisDownloadTemplate/TnrisDownloadTemplate.jsx
@@ -18,6 +18,7 @@ export default class TnrisDownloadTemplate extends React.Component {
       };
       this.setTemplateView = this.setTemplateView.bind(this);
       this.showTabMenu = this.showTabMenu.bind(this);
+      this.handleBack = this.handleBack.bind(this);
   }
 
   componentDidMount() {
@@ -63,6 +64,22 @@ export default class TnrisDownloadTemplate extends React.Component {
   showTabMenu() {
     this.menu = new MDCMenu(this.refs.tab_menu);
     this.menu.open = true;
+  }
+
+  handleBack() {
+    console.log('handleBack')
+    if (this.props.previousUrl.includes('/catalog/') || this.props.previousUrl.includes('/')) {
+      this.props.setViewCatalog();
+      this.props.setUrl(this.props.previousUrl);
+    } else if (this.props.previousUrl.includes('/collection/')) {
+        const collectionUuid = this.props.previousUrl.replace('/collection/', '');
+        this.props.setViewCollection();
+        this.props.selectCollection(collectionUuid);
+        this.props.setUrl(this.props.previousUrl);
+    } else {
+        this.props.setViewCatalog();
+        this.props.setUrl(this.props.previousUrl);
+    }
   }
 
   render() {
@@ -194,6 +211,13 @@ export default class TnrisDownloadTemplate extends React.Component {
                         <span className="mdc-tab__ripple"></span>
                       </button>
 
+                      <button
+                        className="mdc-icon-button material-icons close-collection"
+                        onClick={this.handleBack}
+                        title="Close collection view">
+                          close
+                      </button>
+
                     </div>
                   </div>
                 </div>
@@ -221,6 +245,10 @@ export default class TnrisDownloadTemplate extends React.Component {
                     <div className={this.state.view === 'contact' ? 'mdc-list-item  mdc-list-item--activated' : 'mdc-list-item'}
                        onClick={() => this.setTemplateView("contact")}>Contact
                        {/*<i className="mdc-tab__icon material-icons">contact_support</i>*/}
+                    </div>
+                    <div className='mdc-list-item'
+                       onClick={this.handleBack}
+                       title="Close collection view">Close
                     </div>
                   </nav>
                 </div>

--- a/src/components/TnrisDownloadTemplate/TnrisDownloadTemplate.jsx
+++ b/src/components/TnrisDownloadTemplate/TnrisDownloadTemplate.jsx
@@ -185,7 +185,6 @@ export default class TnrisDownloadTemplate extends React.Component {
                         onClick={() => this.setTemplateView("contact")}
                         title="Contact">
                         <span className="mdc-tab__content">contact
-                          {/*<span className="mdc-tab__icon material-icons">save_alt</span>*/}
                         </span>
                         <span className="mdc-tab-indicator">
                           <span
@@ -209,19 +208,15 @@ export default class TnrisDownloadTemplate extends React.Component {
                   <nav className="mdc-list">
                     <div className={this.state.view === 'details' ? 'mdc-list-item  mdc-list-item--activated' : 'mdc-list-item'}
                       onClick={() => this.setTemplateView("details")}>Details
-                      {/*<i className="mdc-tab__icon material-icons">details</i>*/}
                     </div>
                     <div className={this.state.view === 'preview' ? 'mdc-list-item  mdc-list-item--activated' : 'mdc-list-item'}
                       onClick={() => this.setTemplateView("preview")}>Preview
-                      {/*<i className="mdc-tab__icon material-icons">save_alt</i>*/}
                     </div>
                     <div className={this.state.view === 'order' ? 'mdc-list-item  mdc-list-item--activated' : 'mdc-list-item'}
                       onClick={() => this.setTemplateView("order")}>Order
-                      {/*<i className="mdc-tab__icon material-icons">shopping_basket</i>*/}
                     </div>
                     <div className={this.state.view === 'contact' ? 'mdc-list-item  mdc-list-item--activated' : 'mdc-list-item'}
                        onClick={() => this.setTemplateView("contact")}>Contact
-                       {/*<i className="mdc-tab__icon material-icons">contact_support</i>*/}
                     </div>
                   </nav>
                 </div>

--- a/src/components/TnrisDownloadTemplate/TnrisDownloadTemplate.jsx
+++ b/src/components/TnrisDownloadTemplate/TnrisDownloadTemplate.jsx
@@ -9,6 +9,7 @@ import Images from '../Images'
 
 import ContactContainer from '../../containers/ContactContainer'
 import OrderTnrisDataFormContainer from '../../containers/OrderTnrisDataFormContainer'
+import BackButtonContainer from '../../containers/BackButtonContainer'
 
 export default class TnrisDownloadTemplate extends React.Component {
   constructor(props) {
@@ -18,7 +19,6 @@ export default class TnrisDownloadTemplate extends React.Component {
       };
       this.setTemplateView = this.setTemplateView.bind(this);
       this.showTabMenu = this.showTabMenu.bind(this);
-      this.handleBack = this.handleBack.bind(this);
   }
 
   componentDidMount() {
@@ -64,22 +64,6 @@ export default class TnrisDownloadTemplate extends React.Component {
   showTabMenu() {
     this.menu = new MDCMenu(this.refs.tab_menu);
     this.menu.open = true;
-  }
-
-  handleBack() {
-    console.log('handleBack')
-    if (this.props.previousUrl.includes('/catalog/') || this.props.previousUrl.includes('/')) {
-      this.props.setViewCatalog();
-      this.props.setUrl(this.props.previousUrl);
-    } else if (this.props.previousUrl.includes('/collection/')) {
-        const collectionUuid = this.props.previousUrl.replace('/collection/', '');
-        this.props.setViewCollection();
-        this.props.selectCollection(collectionUuid);
-        this.props.setUrl(this.props.previousUrl);
-    } else {
-        this.props.setViewCatalog();
-        this.props.setUrl(this.props.previousUrl);
-    }
   }
 
   render() {
@@ -211,12 +195,7 @@ export default class TnrisDownloadTemplate extends React.Component {
                         <span className="mdc-tab__ripple"></span>
                       </button>
 
-                      <button
-                        className="mdc-icon-button material-icons close-collection"
-                        onClick={this.handleBack}
-                        title="Close collection view">
-                          close
-                      </button>
+                      <BackButtonContainer />
 
                     </div>
                   </div>
@@ -246,12 +225,11 @@ export default class TnrisDownloadTemplate extends React.Component {
                        onClick={() => this.setTemplateView("contact")}>Contact
                        {/*<i className="mdc-tab__icon material-icons">contact_support</i>*/}
                     </div>
-                    <div className='mdc-list-item'
-                       onClick={this.handleBack}
-                       title="Close collection view">Close
-                    </div>
                   </nav>
                 </div>
+
+                <BackButtonContainer />
+
               </div>
 
             </section>

--- a/src/components/TnrisDownloadTemplate/TnrisDownloadTemplate.jsx
+++ b/src/components/TnrisDownloadTemplate/TnrisDownloadTemplate.jsx
@@ -195,8 +195,6 @@ export default class TnrisDownloadTemplate extends React.Component {
                         <span className="mdc-tab__ripple"></span>
                       </button>
 
-                      <BackButtonContainer />
-
                     </div>
                   </div>
                 </div>
@@ -227,10 +225,9 @@ export default class TnrisDownloadTemplate extends React.Component {
                     </div>
                   </nav>
                 </div>
-
-                <BackButtonContainer />
-
               </div>
+
+              <BackButtonContainer />
 
             </section>
           </div>

--- a/src/components/TnrisDownloadTemplate/TnrisDownloadTemplate.jsx
+++ b/src/components/TnrisDownloadTemplate/TnrisDownloadTemplate.jsx
@@ -77,7 +77,8 @@ export default class TnrisDownloadTemplate extends React.Component {
         showComponent = (
           <Images
             thumbnail={this.props.collection.thumbnail_image}
-            images={this.props.collection.images} />
+            images={this.props.collection.images}
+            template={this.props.collection.template} />
         )
         break;
       case 'order':

--- a/src/components/TnrisDownloadTemplate/TnrisDownloadTemplateDetails.jsx
+++ b/src/components/TnrisDownloadTemplate/TnrisDownloadTemplateDetails.jsx
@@ -81,16 +81,14 @@ export default class TnrisDownloadTemplateDetails extends React.Component {
                             {lidarCard}
                             {servicesCard}
                             {supplementalDownloadsCard}
+                            {sourceCitation}
                             <ShareButtons />
                           </div>
                           <div className='mdc-layout-grid__cell mdc-layout-grid__cell--span-8'>
                             {downloadMap}
                             <div className="mdc-layout-grid__inner">
-                              <div className='mdc-layout-grid__cell mdc-layout-grid__cell--span-8'>
+                              <div className='mdc-layout-grid__cell mdc-layout-grid__cell--span-12'>
                                 {description}
-                              </div>
-                              <div className='mdc-layout-grid__cell mdc-layout-grid__cell--span-4'>
-                                {sourceCitation}
                               </div>
                             </div>
                           </div>

--- a/src/components/TnrisDownloadTemplate/TnrisDownloadTemplateDownload.jsx
+++ b/src/components/TnrisDownloadTemplate/TnrisDownloadTemplateDownload.jsx
@@ -154,7 +154,6 @@ export default class TnrisDownloadTemplateDownload extends React.Component {
       id: 'download-menu',
       className: 'tnris-download-menu',
       title: 'Download Area Selector'
-      // eventHandler: ''
     });
 
     const areaTypesAry = Object.keys(this.props.resourceAreaTypes).sort();
@@ -378,13 +377,8 @@ export default class TnrisDownloadTemplateDownload extends React.Component {
     // wire an on-click event to the area_type polygons to show a popup of
     // available resource downloads for clicked area
     const areaLookup = this.areaLookup;
-    // instruction popup for on hover instructions
-    // const instructions = new mapboxgl.Popup({
-    //   closeButton: false,
-    //   closeOnClick: false
-    // });
+
     map.on('click', layerBaseName, function (e) {
-      // instructions.remove();
       const clickedAreaId = e.features[0].properties.area_type_id;
       const clickedAreaName = e.features[0].properties.area_type_name;
       const downloads = areaLookup[clickedAreaId];
@@ -415,18 +409,12 @@ export default class TnrisDownloadTemplateDownload extends React.Component {
     map.on('mousemove', layerBaseName, function (e) {
       map.getCanvas().style.cursor = 'pointer';
       map.setFilter(layerHoverName, ['==', 'area_type_name', e.features[0].properties.area_type_name]);
-      // add hover instructions
-      // instructions.setLngLat(e.lngLat)
-      //             .setHTML(`<p style='text-align:center;'>Click this polygon to download <br> <strong>${e.features[0].properties.area_type_name}</strong> data.`)
-      //             .addTo(map);
     });
     // Undo the cursor pointer when it leaves a feature in the 'area_type' layer
     // Also, untoggle the hover layer with a filter
     map.on('mouseleave', layerBaseName, function () {
       map.getCanvas().style.cursor = '';
       map.setFilter(layerHoverName, ['==', 'area_type_name', '']);
-      // remove hover instructions
-      // instructions.remove();
     });
   }
 

--- a/src/components/TnrisOrderTemplate/TnrisOrderTemplate.jsx
+++ b/src/components/TnrisOrderTemplate/TnrisOrderTemplate.jsx
@@ -177,8 +177,6 @@ export default class TnrisOrderTemplate extends React.Component {
                         <span className="mdc-tab__ripple"></span>
                       </button>
 
-                      <BackButtonContainer />
-
                     </div>
                   </div>
                 </div>
@@ -216,10 +214,9 @@ export default class TnrisOrderTemplate extends React.Component {
                     </div>
                   </nav>
                 </div>
-
-                <BackButtonContainer />
-                
               </div>
+
+              <BackButtonContainer />
 
             </section>
           </div>

--- a/src/components/TnrisOrderTemplate/TnrisOrderTemplate.jsx
+++ b/src/components/TnrisOrderTemplate/TnrisOrderTemplate.jsx
@@ -169,7 +169,6 @@ export default class TnrisOrderTemplate extends React.Component {
 
                       <button className="mdc-tab" role="tab" aria-selected="false" tabIndex="-1"  onClick={() => this.setTemplateView("contact")} title="Contact">
                         <span className="mdc-tab__content">contact
-                          {/*<span className="mdc-tab__icon material-icons">contact_support</span>*/}
                         </span>
                         <span className="mdc-tab-indicator">
                           <span className="mdc-tab-indicator__content mdc-tab-indicator__content--underline"></span>
@@ -191,26 +190,15 @@ export default class TnrisOrderTemplate extends React.Component {
                   <nav className="mdc-list">
                     <div className={this.state.view === 'details' ? 'mdc-list-item  mdc-list-item--activated' : 'mdc-list-item'}
                        onClick={() => this.setTemplateView("details")}>Details
-                       {/*<i className="mdc-tab__icon material-icons">details</i>*/}
                     </div>
                     <div className={this.state.view === 'preview' ? 'mdc-list-item  mdc-list-item--activated' : 'mdc-list-item'}
                        onClick={() => this.setTemplateView("preview")}>Preview
-                       {/*<i className="mdc-tab__icon material-icons">details</i>*/}
                     </div>
-                    {/* this.props.collection.counties ? (
-                      <div className={this.state.view === 'coverage' ? 'mdc-list-item  mdc-list-item--activated' : 'mdc-list-item'}
-                         onClick={() => this.setTemplateView("coverage")}>Coverage
-
-                      </div>
-                      ) : ""
-                    */}
                     <div className={this.state.view === 'order' ? 'mdc-list-item  mdc-list-item--activated' : 'mdc-list-item'}
                        onClick={() => this.setTemplateView("order")}>Order
-                       {/*<i className="mdc-tab__icon material-icons">shopping_basket</i>*/}
                     </div>
                     <div className={this.state.view === 'contact' ? 'mdc-list-item  mdc-list-item--activated' : 'mdc-list-item'}
                        onClick={() => this.setTemplateView("contact")}>Contact
-                       {/*<i className="mdc-tab__icon material-icons">contact_support</i>*/}
                     </div>
                   </nav>
                 </div>

--- a/src/components/TnrisOrderTemplate/TnrisOrderTemplate.jsx
+++ b/src/components/TnrisOrderTemplate/TnrisOrderTemplate.jsx
@@ -9,6 +9,7 @@ import Images from '../Images'
 
 import ContactContainer from '../../containers/ContactContainer'
 import OrderTnrisDataFormContainer from '../../containers/OrderTnrisDataFormContainer'
+import BackButtonContainer from '../../containers/BackButtonContainer'
 
 export default class TnrisOrderTemplate extends React.Component {
   constructor(props) {
@@ -176,6 +177,8 @@ export default class TnrisOrderTemplate extends React.Component {
                         <span className="mdc-tab__ripple"></span>
                       </button>
 
+                      <BackButtonContainer />
+
                     </div>
                   </div>
                 </div>
@@ -213,6 +216,9 @@ export default class TnrisOrderTemplate extends React.Component {
                     </div>
                   </nav>
                 </div>
+
+                <BackButtonContainer />
+                
               </div>
 
             </section>

--- a/src/components/TnrisOrderTemplate/TnrisOrderTemplate.jsx
+++ b/src/components/TnrisOrderTemplate/TnrisOrderTemplate.jsx
@@ -65,7 +65,8 @@ export default class TnrisOrderTemplate extends React.Component {
         showComponent = (
           <Images
             thumbnail={this.props.collection.thumbnail_image}
-            images={this.props.collection.images} />
+            images={this.props.collection.images}
+            template={this.props.collection.template} />
         )
         break;
       case 'order':

--- a/src/components/TnrisOrderTemplate/TnrisOrderTemplateDetails.jsx
+++ b/src/components/TnrisOrderTemplate/TnrisOrderTemplateDetails.jsx
@@ -84,7 +84,6 @@ export default class TnrisDownloadTemplateDetails extends React.Component {
                               <ShareButtons />
                             </div>
                             <div className='mdc-layout-grid__cell mdc-layout-grid__cell--span-8'>
-                              {/*{imageCarousel}*/}
                               {countyCoverage}
                               <div className="mdc-layout-grid__inner">
                                 <div className='mdc-layout-grid__cell mdc-layout-grid__cell--span-8'>
@@ -98,7 +97,6 @@ export default class TnrisDownloadTemplateDetails extends React.Component {
                           </div>) : (
                           <div className="mdc-layout-grid__inner">
                             <div className='mdc-layout-grid__cell mdc-layout-grid__cell--span-12'>
-                              {/*{imageCarousel}*/}
                               {countyCoverage}
                               <Metadata collection={this.props.collection} />
                               {description}

--- a/src/components/TnrisOrderTemplate/TnrisOrderTemplateDetails.jsx
+++ b/src/components/TnrisOrderTemplate/TnrisOrderTemplateDetails.jsx
@@ -81,16 +81,14 @@ export default class TnrisDownloadTemplateDetails extends React.Component {
                               {lidarCard}
                               {servicesCard}
                               {supplementalDownloadsCard}
+                              {sourceCitation}
                               <ShareButtons />
                             </div>
                             <div className='mdc-layout-grid__cell mdc-layout-grid__cell--span-8'>
                               {countyCoverage}
                               <div className="mdc-layout-grid__inner">
-                                <div className='mdc-layout-grid__cell mdc-layout-grid__cell--span-8'>
+                                <div className='mdc-layout-grid__cell mdc-layout-grid__cell--span-12'>
                                   {description}
-                                </div>
-                                <div className='mdc-layout-grid__cell mdc-layout-grid__cell--span-4'>
-                                  {sourceCitation}
                                 </div>
                               </div>
                             </div>

--- a/src/components/TnrisOutsideEntityTemplate/TnrisOutsideEntityTemplate.jsx
+++ b/src/components/TnrisOutsideEntityTemplate/TnrisOutsideEntityTemplate.jsx
@@ -5,6 +5,7 @@ import {MDCMenu} from '@material/menu'
 
 import TnrisOutsideEntityTemplateDetails from './TnrisOutsideEntityTemplateDetails'
 import ContactOutsideContainer from '../../containers/ContactOutsideContainer'
+import BackButtonContainer from '../../containers/BackButtonContainer'
 
 export default class TnrisOutsideEntityTemplate extends React.Component {
   constructor(props) {
@@ -90,7 +91,6 @@ export default class TnrisOutsideEntityTemplate extends React.Component {
 
                       <button className="mdc-tab mdc-tab--active" role="tab" aria-selected="true" tabIndex="0" onClick={() => this.setTemplateView("details")} title="Details">
                         <span className="mdc-tab__content">details
-                          {/*<span className="mdc-tab__icon material-icons">details</span>*/}
                         </span>
                         <span className="mdc-tab-indicator mdc-tab-indicator--active">
                           <span className="mdc-tab-indicator__content mdc-tab-indicator__content--underline"></span>
@@ -100,7 +100,6 @@ export default class TnrisOutsideEntityTemplate extends React.Component {
 
                       <button className="mdc-tab" role="tab" aria-selected="false" tabIndex="-1"  onClick={() => this.setTemplateView("contact")} title="Contact">
                         <span className="mdc-tab__content">contact
-                          {/*<span className="mdc-tab__icon material-icons">contact_support</span>*/}
                         </span>
                         <span className="mdc-tab-indicator">
                           <span className="mdc-tab-indicator__content mdc-tab-indicator__content--underline"></span>
@@ -122,15 +121,15 @@ export default class TnrisOutsideEntityTemplate extends React.Component {
                   <nav className="mdc-list">
                     <div className={this.state.view === 'details' ? 'mdc-list-item  mdc-list-item--activated' : 'mdc-list-item'}
                        onClick={() => this.setTemplateView("details")}>Details
-                       {/*<i className="mdc-tab__icon material-icons">details</i>*/}
                     </div>
                     <div className={this.state.view === 'contact' ? 'mdc-list-item  mdc-list-item--activated' : 'mdc-list-item'}
                        onClick={() => this.setTemplateView("contact")}>Contact
-                       {/*<i className="mdc-tab__icon material-icons">contact_support</i>*/}
                     </div>
                   </nav>
                 </div>
               </div>
+
+              <BackButtonContainer />
 
             </section>
           </div>

--- a/src/components/TnrisOutsideEntityTemplate/TnrisOutsideEntityTemplateDetails.jsx
+++ b/src/components/TnrisOutsideEntityTemplate/TnrisOutsideEntityTemplateDetails.jsx
@@ -19,7 +19,8 @@ export default class TnrisOutsideEntityTemplateDetails extends React.Component {
     const imageCarousel = this.props.collection.images ? (
                         <Images
                           thumbnail={this.props.collection.thumbnail_image}
-                          images={this.props.collection.images} />)
+                          images={this.props.collection.images}
+                          template={this.props.collection.template} />)
                         : "";
 
     const externalEntityBlurb = (
@@ -40,17 +41,15 @@ export default class TnrisOutsideEntityTemplateDetails extends React.Component {
                           <div className="mdc-layout-grid__inner">
                             <div className='mdc-layout-grid__cell mdc-layout-grid__cell--span-4'>
                               <Metadata collection={this.props.collection} />
+                              {externalEntityBlurb}
                               <ShareButtons />
                               <OeServices collection={this.props.collection} />
                             </div>
                             <div className='mdc-layout-grid__cell mdc-layout-grid__cell--span-8'>
                               {imageCarousel}
                               <div className="mdc-layout-grid__inner">
-                                <div className='mdc-layout-grid__cell mdc-layout-grid__cell--span-8'>
+                                <div className='mdc-layout-grid__cell mdc-layout-grid__cell--span-12'>
                                   <Description collection={this.props.collection} />
-                                </div>
-                                <div className='mdc-layout-grid__cell mdc-layout-grid__cell--span-4'>
-                                  {externalEntityBlurb}
                                 </div>
                               </div>
                             </div>

--- a/src/containers/BackButtonContainer.jsx
+++ b/src/containers/BackButtonContainer.jsx
@@ -7,7 +7,9 @@ import {catalogActions,
         urlTrackerActions} from '../actions'
 
 const mapStateToProps = state => ({
-  previousUrl: state.urlTracker.previousUrl
+  previousUrl: state.urlTracker.previousUrl,
+  catalogFilterUrl: state.urlTracker.catalogFilterUrl,
+  view: state.catalog.view
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/containers/BackButtonContainer.jsx
+++ b/src/containers/BackButtonContainer.jsx
@@ -1,6 +1,6 @@
 import {connect} from 'react-redux'
 
-import OrderCartView from '../components/OrderCartView'
+import BackButton from '../components/DialogTemplateListItems/BackButton'
 
 import {catalogActions,
         collectionActions,
@@ -25,9 +25,9 @@ const mapDispatchToProps = (dispatch) => ({
   },
 })
 
-const OrderCartViewContainer = connect(
+const BackButtonContainer = connect(
   mapStateToProps,
   mapDispatchToProps
-)(OrderCartView);
+)(BackButton);
 
-export default OrderCartViewContainer;
+export default BackButtonContainer;

--- a/src/containers/TnrisDownloadTemplateContainer.jsx
+++ b/src/containers/TnrisDownloadTemplateContainer.jsx
@@ -1,14 +1,31 @@
 import {connect} from 'react-redux'
 
-import {collectionActions} from '../actions'
 import TnrisDownloadTemplate from '../components/TnrisDownloadTemplate/TnrisDownloadTemplate'
 
-const mapStateToProps = state => ({});
+import {catalogActions,
+        collectionActions,
+        urlTrackerActions} from '../actions'
+
+const mapStateToProps = state => ({
+  previousUrl: state.urlTracker.previousUrl
+});
 
 const mapDispatchToProps = (dispatch) => ({
-    fetchCollectionResources: (collectionId) => {
-      dispatch(collectionActions.fetchCollectionResources(collectionId))
-    }
+  fetchCollectionResources: (collectionId) => {
+    dispatch(collectionActions.fetchCollectionResources(collectionId))
+  },
+  setUrl: (newUrl) => {
+    dispatch(urlTrackerActions.setUrl(newUrl))
+  },
+  setViewCatalog: () => {
+    dispatch(catalogActions.setViewCatalog());
+  },
+  setViewCollection: () => {
+    dispatch(catalogActions.setViewCollection());
+  },
+  selectCollection: (collectionId) => {
+    dispatch(collectionActions.selectCollection(collectionId));
+  },
 })
 
 const TnrisDownloadTemplateContainer = connect(

--- a/src/containers/TnrisDownloadTemplateContainer.jsx
+++ b/src/containers/TnrisDownloadTemplateContainer.jsx
@@ -2,9 +2,7 @@ import {connect} from 'react-redux'
 
 import TnrisDownloadTemplate from '../components/TnrisDownloadTemplate/TnrisDownloadTemplate'
 
-import {catalogActions,
-        collectionActions,
-        urlTrackerActions} from '../actions'
+import {collectionActions} from '../actions'
 
 const mapStateToProps = state => ({
   previousUrl: state.urlTracker.previousUrl
@@ -13,18 +11,6 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = (dispatch) => ({
   fetchCollectionResources: (collectionId) => {
     dispatch(collectionActions.fetchCollectionResources(collectionId))
-  },
-  setUrl: (newUrl) => {
-    dispatch(urlTrackerActions.setUrl(newUrl))
-  },
-  setViewCatalog: () => {
-    dispatch(catalogActions.setViewCatalog());
-  },
-  setViewCollection: () => {
-    dispatch(catalogActions.setViewCollection());
-  },
-  selectCollection: (collectionId) => {
-    dispatch(collectionActions.selectCollection(collectionId));
   },
 })
 

--- a/src/sass/_backButton.scss
+++ b/src/sass/_backButton.scss
@@ -1,0 +1,8 @@
+/*
+back button class for backButton component
+*/
+
+.close-collection {
+  background-color: #e6e6e6;
+  border-radius: 50%;
+}

--- a/src/sass/_catalog.scss
+++ b/src/sass/_catalog.scss
@@ -6,8 +6,12 @@ styles for component: Catalog
 .catalog-component {
   margin-bottom: 75px;
 
-  .view-container {
+  .catalog-view-container {
     padding-top: 106px;
+  }
+
+  .other-view-container {
+    padding-top: 40px;
   }
 
   .mdc-dialog {

--- a/src/sass/_catalog.scss
+++ b/src/sass/_catalog.scss
@@ -11,7 +11,7 @@ styles for component: Catalog
   }
 
   .other-view-container {
-    padding-top: 40px;
+    padding-top: 35px;
     width: 100%;
     height: auto;
   }

--- a/src/sass/_catalog.scss
+++ b/src/sass/_catalog.scss
@@ -12,6 +12,8 @@ styles for component: Catalog
 
   .other-view-container {
     padding-top: 40px;
+    width: 100%;
+    height: auto;
   }
 
   .mdc-dialog {

--- a/src/sass/_collectionFilterMap.scss
+++ b/src/sass/_collectionFilterMap.scss
@@ -1,8 +1,8 @@
 .collection-filter-map-component {
 
   #collection-filter-map {
-    position:absolute;
-    top: 170px;
+    position: absolute;
+    top: 110px;
     left: 0;
     bottom: 50px;
     width: 100%;
@@ -34,7 +34,7 @@
     color: $nest-text;
     position: absolute;
     z-index: 2;
-    top: 180px;
+    top: 120px;
     right: 10px;
     border-radius: 3px;
     border: 1px solid rgba(0,0,0,0.4);

--- a/src/sass/_collectionFilterMapView.scss
+++ b/src/sass/_collectionFilterMapView.scss
@@ -12,18 +12,13 @@ styles for component: CollectionFilterMapView
     padding-bottom: 1px;
   }
 
-  .close-shopping-cart {
-    background-color: #e6e6e6;
-    border-radius: 50%;
-  }
-
   .county-select__wrapper {
     padding-right: 50px;
-    margin-top: 4px;
+    margin-top: 15px;
 
     .mdc-notched-outline {
       padding: 1px 0px 1px 0px;
-      
+
       .mdc-notched-outline__leading, .mdc-notched-outline__trailing {
         border-radius: unset;
       }

--- a/src/sass/_collectionTemplateDetails.scss
+++ b/src/sass/_collectionTemplateDetails.scss
@@ -6,7 +6,7 @@ shared styles for collection TemplateDetails components
 .tnris-order-template-details,
 .historical-aerial-template-details,
 .outside-entity-template-details {
-  padding: 0;
+  padding: 50px 0 0 0;
   overflow-x: hidden;
   overflow-y: auto;
 
@@ -40,6 +40,10 @@ shared styles for collection TemplateDetails components
       &.-expanded {
         max-height: 100vh;
       }
+    }
+
+    .mw-empty-elt {
+      display: none;
     }
 
     .fade-text:not(.-expanded)::after {

--- a/src/sass/_collectionTemplates.scss
+++ b/src/sass/_collectionTemplates.scss
@@ -93,6 +93,11 @@ shared styles for collection base Template components
     // header right hand section, tabs and dropdown - END
   }
   // header element - END
+
+  .close-collection {
+    background-color: #e6e6e6;
+    border-radius: 50%;
+  }
 }
 
 // template images - used for download, historical and order

--- a/src/sass/_collectionTemplates.scss
+++ b/src/sass/_collectionTemplates.scss
@@ -18,7 +18,8 @@ shared styles for collection base Template components
   header {
     @include mdc-top-app-bar-fill-color($main-background);
     z-index: 3;
-    position: relative;
+    // position: relative;
+    position: fixed;
 
     // collection title, show in left hand section
     .mdc-top-app-bar__title {
@@ -97,13 +98,11 @@ shared styles for collection base Template components
 
 // template images - used for download, historical and order
 .tnris-template-images {
-  padding-top: 10px;
   max-width: 1200px;
   margin: 0 auto;
 
   // nested images (image carousel) component - BEGIN
   .image-container {
-    padding: 0 40px 0 40px;
 
     @media (max-width: $breakpoint-tablet) {
       padding: 0 15px 0 15px;
@@ -159,6 +158,10 @@ shared styles for collection base Template components
       top: 50%; /* 50% from the top of the container */
       transform: translateY(-50%); /* -50% of the height of the image */
     }
+  }
+
+  .pad-class {
+    padding: 80px 40px 0 40px;
   }
   // nested images (image carousel) component - END
 }

--- a/src/sass/_collectionTemplates.scss
+++ b/src/sass/_collectionTemplates.scss
@@ -93,11 +93,6 @@ shared styles for collection base Template components
     // header right hand section, tabs and dropdown - END
   }
   // header element - END
-
-  .close-collection {
-    background-color: #e6e6e6;
-    border-radius: 50%;
-  }
 }
 
 // template images - used for download, historical and order

--- a/src/sass/_componentSassImporter.scss
+++ b/src/sass/_componentSassImporter.scss
@@ -15,6 +15,7 @@ them here to have them available to the app
 @import 'collectionTimeslider';
 @import 'contactTnrisForm';
 @import 'countyCoverageMap';
+@import 'backButton';
 @import 'drawer';
 @import 'footer';
 @import 'header';

--- a/src/sass/_contactTnrisForm.scss
+++ b/src/sass/_contactTnrisForm.scss
@@ -8,7 +8,7 @@ styles for component: ContactTnrisForm
   @include mdc-text-field-line-ripple-color($primary-color);
   @include mdc-text-field-textarea-stroke-color(rgba(0, 0, 0, 0.12));
 
-  padding: 0px 20px 20px 20px;
+  padding: 10px 20px 20px 20px;
   min-height: 200px;
   overflow-y: auto;
   overflow-x: hidden;

--- a/src/sass/_countyCoverageMap.scss
+++ b/src/sass/_countyCoverageMap.scss
@@ -9,7 +9,7 @@ styles for component: CountyCoverage
   #county-coverage-map {
     position: relative;
     width: auto;
-    height: 55vh;
+    height: 62vh;
     top: 0;
 
     .mapboxgl-canvas {

--- a/src/sass/_orderTnrisDataForm.scss
+++ b/src/sass/_orderTnrisDataForm.scss
@@ -16,7 +16,7 @@ styles for component: OrderTnrisDataForm
     border-color: $nest-text;
   }
 
-  padding: 0px 20px 20px 20px;
+  padding: 10px 20px 20px 20px;
   min-height: 200px;
   overflow-y: auto;
   overflow-x: hidden;

--- a/src/sass/_tnrisDownloadTemplateDownload.scss
+++ b/src/sass/_tnrisDownloadTemplateDownload.scss
@@ -12,7 +12,7 @@ styles for component: TnrisDownloadTemplateDownload
   #tnris-download-map {
     position: relative;
     width: auto;
-    height: 55vh;
+    height: 60vh;
     top: 0;
 
     .mapboxgl-canvas {

--- a/src/sass/_tnrisDownloadTemplateDownload.scss
+++ b/src/sass/_tnrisDownloadTemplateDownload.scss
@@ -12,7 +12,7 @@ styles for component: TnrisDownloadTemplateDownload
   #tnris-download-map {
     position: relative;
     width: auto;
-    height: 60vh;
+    height: 62vh;
     top: 0;
 
     .mapboxgl-canvas {

--- a/src/sass/_tnrisDownloadTemplateDownload.scss
+++ b/src/sass/_tnrisDownloadTemplateDownload.scss
@@ -57,7 +57,7 @@ styles for component: TnrisDownloadTemplateDownload
   .tnris-download-template-download__mobile {
     background: $main-background;
     color: $nest-text;
-    padding: 35px;
+    padding: 20px;
   }
 
   .tnris-download-template-download__loading {


### PR DESCRIPTION
remove header from all views except catalog; sass adjustments all over; re-org sub-components on collection details view - dataset citation & external entity disclaimer moved to left side, description now full width of grid columns.

closes issue #222 and related to #226 