### PR TITLE
sass tweaks and cleanup, coverage & download maps

### DIFF
--- a/src/components/CollectionFilterMap.jsx
+++ b/src/components/CollectionFilterMap.jsx
@@ -118,7 +118,9 @@ export default class CollectionFilterMap extends React.Component {
     });
     this._map = map;
 
-    this._navControl = new mapboxgl.NavigationControl()
+    this._navControl = new mapboxgl.NavigationControl({
+      showCompass: false
+    });
     map.addControl(this._navControl, 'top-left');
 
     // Define custom map control to reset the map to its

--- a/src/components/DialogTemplateListItems/CountyCoverage.jsx
+++ b/src/components/DialogTemplateListItems/CountyCoverage.jsx
@@ -34,17 +34,13 @@ export default class CountyCoverage extends React.Component {
     // add regular out-of-the-box controls if they dont already exist
     // prevents stacking/duplicating controls on component update
     if (!document.querySelector('.mapboxgl-ctrl-zoom-in')) {
-      map.addControl(new mapboxgl.NavigationControl(), 'top-left');
+      map.addControl(new mapboxgl.NavigationControl({
+        showCompass: false
+      }), 'top-left');
     }
     if (!document.querySelector('.mapboxgl-ctrl-fullscreen')) {
       map.addControl(new mapboxgl.FullscreenControl(), 'top-right');
     }
-
-    // add tooltips for map controls
-    document.querySelector('.mapboxgl-ctrl-zoom-in').setAttribute('title', 'Zoom In');
-    document.querySelector('.mapboxgl-ctrl-zoom-out').setAttribute('title', 'Zoom Out');
-    document.querySelector('.mapboxgl-ctrl-compass-arrow').setAttribute('title', 'Compass Arrow');
-    document.querySelector(".mapboxgl-ctrl-fullscreen").setAttribute('title', 'Fullscreen Map');
 
     const re = new RegExp(", ", 'g');
     const quotedCounties = this.props.counties.replace(re, "','");

--- a/src/components/TnrisDownloadTemplate/TnrisDownloadTemplateDownload.jsx
+++ b/src/components/TnrisDownloadTemplate/TnrisDownloadTemplateDownload.jsx
@@ -112,7 +112,9 @@ export default class TnrisDownloadTemplateDownload extends React.Component {
     // add regular out-of-the-box controls if they dont already exist
     // prevents stacking/duplicating controls on component update
     if (!document.querySelector('.mapboxgl-ctrl-zoom-in')) {
-      map.addControl(new mapboxgl.NavigationControl(), 'top-left');
+      map.addControl(new mapboxgl.NavigationControl({
+        showCompass: false
+      }), 'top-left');
     }
     if (!document.querySelector('.mapboxgl-ctrl-fullscreen')) {
       map.addControl(new mapboxgl.FullscreenControl(), 'top-right');
@@ -199,12 +201,6 @@ export default class TnrisDownloadTemplateDownload extends React.Component {
         map.addControl(ctrlMenu, 'top-right')
       }
     }
-
-    // add tooltips for all map controls
-    document.querySelector('.mapboxgl-ctrl-zoom-in').setAttribute('title', 'Zoom In');
-    document.querySelector('.mapboxgl-ctrl-zoom-out').setAttribute('title', 'Zoom Out');
-    document.querySelector('.mapboxgl-ctrl-compass-arrow').setAttribute('title', 'Compass Arrow');
-    document.querySelector('.mapboxgl-ctrl-fullscreen').setAttribute('title', 'Fullscreen Map');
 
     // add custom controls to map
     const menuItems = document.querySelector('#download-menu');

--- a/src/sass/_collectionTemplateDetails.scss
+++ b/src/sass/_collectionTemplateDetails.scss
@@ -10,10 +10,6 @@ shared styles for collection TemplateDetails components
   overflow-x: hidden;
   overflow-y: auto;
 
-  @media (min-width: $breakpoint-desktop) {
-    padding: 0 5%;
-  }
-
   // main template content container div - BEGIN
   .template-content-div {
     margin-bottom: 15px;
@@ -29,50 +25,6 @@ shared styles for collection TemplateDetails components
       white-space: pre-line;
     }
     // general elements - END
-
-    // used for description component (fade text) - used by all details templates
-    .fade-text {
-      position: relative;
-      max-height: 300px;
-      overflow: hidden;
-      transition: max-height 2s ease;
-
-      .mw-empty-elt {
-        display: none;
-      }
-
-      &.-expanded {
-        max-height: 100vh;
-      }
-    }
-
-    .mw-empty-elt {
-      display: none;
-    }
-
-    .fade-text:not(.-expanded)::after {
-      content: '';
-      position: absolute;
-      top: 0;
-      bottom: 0;
-      left: 0;
-      right: 0;
-      background: linear-gradient(rgba($main-background, 0), rgba($main-background, 1));
-    }
-
-    .expand {
-      width: 100%;
-      height: auto;
-      margin-top: 20px;
-      background-color: $primary-color;
-      color: $button-text;
-    }
-
-    .wiki-attribution {
-      font-size: 12px;
-      margin-bottom: 10px;
-    }
-    // end description component (fade-text)
 
     // source citation component
     .citation-container {

--- a/src/sass/_collectionTemplateDetails.scss
+++ b/src/sass/_collectionTemplateDetails.scss
@@ -6,9 +6,13 @@ shared styles for collection TemplateDetails components
 .tnris-order-template-details,
 .historical-aerial-template-details,
 .outside-entity-template-details {
-  padding: 50px 0 0 0;
+  margin: 50px 0 0 0;
   overflow-x: hidden;
   overflow-y: auto;
+
+  @media (min-width: $breakpoint-desktop) {
+    padding: 0 5%;
+  }
 
   // main template content container div - BEGIN
   .template-content-div {

--- a/src/sass/_collectionTemplates.scss
+++ b/src/sass/_collectionTemplates.scss
@@ -97,7 +97,7 @@ shared styles for collection base Template components
 
 // template images - used for download, historical and order
 .tnris-template-images {
-  max-width: 1200px;
+  max-width: 1400px;
   margin: 0 auto;
 
   // nested images (image carousel) component - BEGIN

--- a/src/sass/_collectionTemplates.scss
+++ b/src/sass/_collectionTemplates.scss
@@ -24,6 +24,7 @@ shared styles for collection base Template components
     .mdc-top-app-bar__title {
       font-family: 'Roboto Condensed', sans-serif;
       font-size: 1.7rem;
+      padding-left: 0;
       color: $nest-text;
     }
 

--- a/src/sass/_collectionTemplates.scss
+++ b/src/sass/_collectionTemplates.scss
@@ -18,7 +18,6 @@ shared styles for collection base Template components
   header {
     @include mdc-top-app-bar-fill-color($main-background);
     z-index: 3;
-    // position: relative;
     position: fixed;
 
     // collection title, show in left hand section

--- a/src/sass/_collectionTemplates.scss
+++ b/src/sass/_collectionTemplates.scss
@@ -24,20 +24,35 @@ shared styles for collection base Template components
     .mdc-top-app-bar__title {
       font-family: 'Roboto Condensed', sans-serif;
       font-size: 1.7rem;
-      padding-left: 0;
       color: $nest-text;
+      padding: 0;
+    }
+
+    // header left hand section, collection title
+    section.mdc-top-app-bar__section.mdc-top-app-bar__section--align-start {
+      width: auto;
+      padding: 8px 8px 8px 32px;
+
+      @media (max-width: $breakpoint-tablet) {
+        padding: 8px 8px 8px 24px;
+      }
     }
 
     // header right hand section, tabs and dropdown - BEGIN
     section.mdc-top-app-bar__section.mdc-top-app-bar__section--align-end {
       width: auto;
+      padding: 8px 32px 8px 8px;
+
+      @media (max-width: $breakpoint-tablet) {
+        padding: 8px 24px 8px 8px;
+      }
 
       // desktop tabs
       div.mdc-tab-bar {
         .mdc-tab {
           max-width: 86px;
-          margin-left: 15px;
-          margin-right: 15px;
+          margin-left: 10px;
+          margin-right: 10px;
           span {
             color: $nest-text-subtle;
           }
@@ -98,7 +113,7 @@ shared styles for collection base Template components
 
 // template images - used for download, historical and order
 .tnris-template-images {
-  max-width: 1400px;
+  max-width: 1300px;
   margin: 0 auto;
 
   // nested images (image carousel) component - BEGIN

--- a/src/sass/_contactTnrisForm.scss
+++ b/src/sass/_contactTnrisForm.scss
@@ -8,7 +8,7 @@ styles for component: ContactTnrisForm
   @include mdc-text-field-line-ripple-color($primary-color);
   @include mdc-text-field-textarea-stroke-color(rgba(0, 0, 0, 0.12));
 
-  margin: 20px 20px 20px 20px;
+  margin: 20px 20px;
   min-height: 200px;
   overflow-y: auto;
   overflow-x: hidden;

--- a/src/sass/_contactTnrisForm.scss
+++ b/src/sass/_contactTnrisForm.scss
@@ -8,13 +8,13 @@ styles for component: ContactTnrisForm
   @include mdc-text-field-line-ripple-color($primary-color);
   @include mdc-text-field-textarea-stroke-color(rgba(0, 0, 0, 0.12));
 
-  margin: 20px 20px;
+  padding: 24px;
   min-height: 200px;
   overflow-y: auto;
   overflow-x: hidden;
 
-  @media (min-width: $breakpoint-desktop) {
-    padding: 0 10%;
+  @media (max-width: $breakpoint-tablet) {
+    padding: 16px;
   }
 
   p.mdc-typography--body2 {

--- a/src/sass/_contactTnrisForm.scss
+++ b/src/sass/_contactTnrisForm.scss
@@ -8,10 +8,14 @@ styles for component: ContactTnrisForm
   @include mdc-text-field-line-ripple-color($primary-color);
   @include mdc-text-field-textarea-stroke-color(rgba(0, 0, 0, 0.12));
 
-  padding: 10px 20px 20px 20px;
+  margin: 20px 20px 20px 20px;
   min-height: 200px;
   overflow-y: auto;
   overflow-x: hidden;
+
+  @media (min-width: $breakpoint-desktop) {
+    padding: 0 10%;
+  }
 
   p.mdc-typography--body2 {
     margin-bottom: 6px;

--- a/src/sass/_header.scss
+++ b/src/sass/_header.scss
@@ -91,7 +91,7 @@ styles for component: Header
 
     #app-title {
       border: none;
-      padding: 0px 0px 0px 20px;
+      padding: 0px 0px 0px 12px;
       font-family: 'Roboto Condensed', sans-serif;
       color: $nest-text;
       background-color: rgba(0, 0, 0, 0);

--- a/src/sass/_orderCart.scss
+++ b/src/sass/_orderCart.scss
@@ -17,8 +17,12 @@ styles for component: OrderCart
     @include mdc-radio-checked-stroke-color($primary-color);
     @include mdc-radio-focus-indicator-color($primary-color)
 
-    padding: 15px;
+    margin: 20px 20px;
     color: $nest-text;
+
+    @media (min-width: $breakpoint-desktop) {
+      padding: 0 10%;
+    }
 
     .order-cart-data-items {
       .mdc-list-item {

--- a/src/sass/_orderTnrisDataForm.scss
+++ b/src/sass/_orderTnrisDataForm.scss
@@ -16,10 +16,14 @@ styles for component: OrderTnrisDataForm
     border-color: $nest-text;
   }
 
-  padding: 10px 20px 20px 20px;
+  margin: 20px 20px 20px 20px;
   min-height: 200px;
   overflow-y: auto;
   overflow-x: hidden;
+
+  @media (min-width: $breakpoint-desktop) {
+    padding: 0 10%;
+  }
 
   div.mdc-text-field {
     border-bottom-width: 1px;

--- a/src/sass/_orderTnrisDataForm.scss
+++ b/src/sass/_orderTnrisDataForm.scss
@@ -16,13 +16,13 @@ styles for component: OrderTnrisDataForm
     border-color: $nest-text;
   }
 
-  margin: 20px 20px;
+  padding: 24px;
   min-height: 200px;
   overflow-y: auto;
   overflow-x: hidden;
 
-  @media (min-width: $breakpoint-desktop) {
-    padding: 0 10%;
+  @media (max-width: $breakpoint-tablet) {
+    padding: 16px;
   }
 
   div.mdc-text-field {

--- a/src/sass/_orderTnrisDataForm.scss
+++ b/src/sass/_orderTnrisDataForm.scss
@@ -16,7 +16,7 @@ styles for component: OrderTnrisDataForm
     border-color: $nest-text;
   }
 
-  margin: 20px 20px 20px 20px;
+  margin: 20px 20px;
   min-height: 200px;
   overflow-y: auto;
   overflow-x: hidden;

--- a/src/sass/_tnrisDownloadTemplateDownload.scss
+++ b/src/sass/_tnrisDownloadTemplateDownload.scss
@@ -57,7 +57,7 @@ styles for component: TnrisDownloadTemplateDownload
   .tnris-download-template-download__mobile {
     background: $main-background;
     color: $nest-text;
-    padding: 20px;
+    padding: 8px 12px 8px 12px;
   }
 
   .tnris-download-template-download__loading {


### PR DESCRIPTION
sass tweaking and cleanup; disable pitch bearing/nav compass tool (issue #134) as it is not utilized and may confuse some users. also playing with replacing the download map disabled on mobile message with a general coverage area map with a short message that says that downloads have been disabled (issue #219). 