### PR TITLE
general sass and component cleanup; closing various issues

### DIFF
--- a/src/components/CollectionFilterMap.jsx
+++ b/src/components/CollectionFilterMap.jsx
@@ -118,7 +118,9 @@ export default class CollectionFilterMap extends React.Component {
     });
     this._map = map;
 
-    this._navControl = new mapboxgl.NavigationControl()
+    this._navControl = new mapboxgl.NavigationControl({
+      showCompass: false
+    });
     map.addControl(this._navControl, 'top-left');
 
     // Define custom map control to reset the map to its

--- a/src/components/CollectionFilterMapView.jsx
+++ b/src/components/CollectionFilterMapView.jsx
@@ -6,6 +6,9 @@ import CollectionFilterMapContainer from '../containers/CollectionFilterMapConta
 
 import BackButtonContainer from '../containers/BackButtonContainer'
 
+// global sass breakpoint variables to be used in js
+import breakpoints from '../sass/_breakpoints.scss'
+
 // the carto core api is a CDN in the app template HTML (not available as NPM package)
 // so we create a constant to represent it so it's available to the component
 const cartodb = window.cartodb;
@@ -18,32 +21,37 @@ export default class CollectionFilterMapView extends React.Component {
     }
     this.getAreaTypeNames = this.getAreaTypeNames.bind(this);
     this.handleChangeCountyName = this.handleChangeCountyName.bind(this);
+    this.downloadBreakpoint = parseInt(breakpoints.download, 10);
   }
 
   componentDidMount() {
     window.scrollTo(0,0);
     this.getAreaTypeNames();
-    const countySelect = new MDCSelect(document.querySelector('.county-select'));
-    // float the label above the select element if there
-    // is an area type selected on render.
-    if (
-      this.props.collectionFilterMapSelectedAreaTypeName &&
-      this.props.collectionFilterMapSelectedAreaType === "county"
-    ) {
-      let adapter = countySelect.foundation_.adapter_;
-      adapter.floatLabel(true);
-      adapter.notchOutline(84.75);
+    if (document.querySelector('.county-select')) {
+      const countySelect = new MDCSelect(document.querySelector('.county-select'));
+      // float the label above the select element if there
+      // is an area type selected on render.
+      if (
+        this.props.collectionFilterMapSelectedAreaTypeName &&
+        this.props.collectionFilterMapSelectedAreaType === "county"
+      ) {
+        let adapter = countySelect.foundation_.adapter_;
+        adapter.floatLabel(true);
+        adapter.notchOutline(84.75);
+      }
     }
   }
 
   componentDidUpdate() {
-    const countySelect = new MDCSelect(document.querySelector('.county-select'));
-    // Disable the select if a map filter is set. Reenable
-    // when the filter is cleared.
-    if (this.props.collectionFilterMapFilter.length > 0) {
-      countySelect.disabled = true;
-    } else {
-      countySelect.disabled = false;
+    if (document.querySelector('.county-select')) {
+      const countySelect = new MDCSelect(document.querySelector('.county-select'));
+      // Disable the select if a map filter is set. Reenable
+      // when the filter is cleared.
+      if (this.props.collectionFilterMapFilter.length > 0) {
+        countySelect.disabled = true;
+      } else {
+        countySelect.disabled = false;
+      }
     }
   }
 
@@ -89,6 +97,30 @@ export default class CollectionFilterMapView extends React.Component {
       return <option value={countyName} key={countyName}>{countyName}</option>;
     }));
 
+    const countySelector = window.innerWidth <= this.downloadBreakpoint ? "" : (
+      <div className="county-select__wrapper">
+        <div className="mdc-select mdc-select--outlined county-select">
+          <i className="mdc-select__dropdown-icon"></i>
+          <select className="mdc-select__native-control"
+            id="county-select"
+            value={
+              this.props.collectionFilterMapSelectedAreaTypeName ?
+              this.props.collectionFilterMapSelectedAreaTypeName : ""}
+            onChange={this.handleChangeCountyName}
+            ref="countySelect">
+            {countyNameOptions}
+          </select>
+          <div className="mdc-notched-outline">
+            <div className="mdc-notched-outline__leading"></div>
+            <div className="mdc-notched-outline__notch">
+              <label className="mdc-floating-label">Select a County</label>
+            </div>
+            <div className="mdc-notched-outline__trailing"></div>
+          </div>
+        </div>
+      </div>
+    );
+
     return (
       <div className="filter-map-view">
         <div className="mdc-top-app-bar__row">
@@ -98,30 +130,8 @@ export default class CollectionFilterMapView extends React.Component {
             </h2>
           </section>
           <section className="mdc-top-app-bar__section mdc-top-app-bar__section--align-end">
-            <div className="county-select__wrapper">
-              <div className="mdc-select mdc-select--outlined county-select">
-                <i className="mdc-select__dropdown-icon"></i>
-                <select className="mdc-select__native-control"
-                  id="county-select"
-                  value={
-                    this.props.collectionFilterMapSelectedAreaTypeName ?
-                    this.props.collectionFilterMapSelectedAreaTypeName : ""}
-                  onChange={this.handleChangeCountyName}
-                  ref="countySelect">
-                  {countyNameOptions}
-                </select>
-                <div className="mdc-notched-outline">
-                  <div className="mdc-notched-outline__leading"></div>
-                  <div className="mdc-notched-outline__notch">
-                    <label className="mdc-floating-label">Select a County</label>
-                  </div>
-                  <div className="mdc-notched-outline__trailing"></div>
-                </div>
-              </div>
-            </div>
-
+            {countySelector}
             <BackButtonContainer />
-
           </section>
         </div>
         <CollectionFilterMapContainer />

--- a/src/components/DialogTemplateListItems/CountyCoverage.jsx
+++ b/src/components/DialogTemplateListItems/CountyCoverage.jsx
@@ -34,17 +34,13 @@ export default class CountyCoverage extends React.Component {
     // add regular out-of-the-box controls if they dont already exist
     // prevents stacking/duplicating controls on component update
     if (!document.querySelector('.mapboxgl-ctrl-zoom-in')) {
-      map.addControl(new mapboxgl.NavigationControl(), 'top-left');
+      map.addControl(new mapboxgl.NavigationControl({
+        showCompass: false
+      }), 'top-left');
     }
     if (!document.querySelector('.mapboxgl-ctrl-fullscreen')) {
       map.addControl(new mapboxgl.FullscreenControl(), 'top-right');
     }
-
-    // add tooltips for map controls
-    document.querySelector('.mapboxgl-ctrl-zoom-in').setAttribute('title', 'Zoom In');
-    document.querySelector('.mapboxgl-ctrl-zoom-out').setAttribute('title', 'Zoom Out');
-    document.querySelector('.mapboxgl-ctrl-compass-arrow').setAttribute('title', 'Compass Arrow');
-    document.querySelector(".mapboxgl-ctrl-fullscreen").setAttribute('title', 'Fullscreen Map');
 
     const re = new RegExp(", ", 'g');
     const quotedCounties = this.props.counties.replace(re, "','");

--- a/src/components/DialogTemplateListItems/CountyCoverage.jsx
+++ b/src/components/DialogTemplateListItems/CountyCoverage.jsx
@@ -151,6 +151,10 @@ export default class CountyCoverage extends React.Component {
 
   render() {
 
+    const downloadsDisabledNote = this.props.counties && this.props.template === 'tnris-download' ? (
+      'Downloads have been disabled for smaller devices. Please use a device with a larger screen size to download data. '
+    ) : "";
+
     return (
 
       <div className="template-content-div county-coverage-component">
@@ -158,7 +162,7 @@ export default class CountyCoverage extends React.Component {
           Coverage Area
         </div>
         <div className='template-content-div-subheader mdc-typography--headline7'>
-          Counties displayed in the map show general coverage for this dataset. Coverage may be incomplete and of varying quality.
+          {downloadsDisabledNote}Counties displayed in the map show general coverage for this dataset. Coverage may be incomplete and of varying quality.
         </div>
         <div id='county-coverage-map'></div>
         <div className='template-content-div-subheader mdc-typography--headline7'>

--- a/src/components/TnrisDownloadTemplate/TnrisDownloadTemplateDetails.jsx
+++ b/src/components/TnrisDownloadTemplate/TnrisDownloadTemplateDetails.jsx
@@ -26,6 +26,7 @@ export default class TnrisDownloadTemplateDetails extends React.Component {
       };
 
     this.handleResize = this.handleResize.bind(this);
+    this.downloadBreakpoint = parseInt(breakpoints.download, 10);
   }
 
   componentDidMount() {
@@ -58,7 +59,7 @@ export default class TnrisDownloadTemplateDetails extends React.Component {
                             template={this.props.collection.template} />
                         ) : "";
 
-    const map = window.innerWidth >= parseInt(breakpoints.tablet, 10) ? downloadMap : coverageMap;
+    const map = window.innerWidth >= this.downloadBreakpoint ? downloadMap : coverageMap;
 
     const lidarCard = this.props.collection.category.includes('Lidar') ? (
                         <LidarBlurb />)

--- a/src/components/TnrisDownloadTemplate/TnrisDownloadTemplateDetails.jsx
+++ b/src/components/TnrisDownloadTemplate/TnrisDownloadTemplateDetails.jsx
@@ -9,6 +9,8 @@ import Supplementals from '../DialogTemplateListItems/Supplementals'
 import ShareButtons from '../DialogTemplateListItems/ShareButtons'
 
 import TnrisDownloadTemplateDownloadContainer from '../../containers/TnrisDownloadTemplateDownloadContainer'
+// coverage map for mobile
+import CountyCoverageContainer from '../../containers/CountyCoverageContainer'
 
 // global sass breakpoint variables to be used in js
 import breakpoints from '../../sass/_breakpoints.scss'
@@ -50,6 +52,14 @@ export default class TnrisDownloadTemplateDetails extends React.Component {
                           <TnrisDownloadTemplateDownloadContainer collectionName={this.props.collection.name} />
                         ) : "";
 
+    const coverageMap = this.props.collection.counties ? (
+                          <CountyCoverageContainer
+                            counties={this.props.collection.counties}
+                            template={this.props.collection.template} />
+                        ) : "";
+
+    const map = window.innerWidth >= parseInt(breakpoints.tablet, 10) ? downloadMap : coverageMap;
+
     const lidarCard = this.props.collection.category.includes('Lidar') ? (
                         <LidarBlurb />)
                         : "";
@@ -85,7 +95,7 @@ export default class TnrisDownloadTemplateDetails extends React.Component {
                             <ShareButtons />
                           </div>
                           <div className='mdc-layout-grid__cell mdc-layout-grid__cell--span-8'>
-                            {downloadMap}
+                            {map}
                             <div className="mdc-layout-grid__inner">
                               <div className='mdc-layout-grid__cell mdc-layout-grid__cell--span-12'>
                                 {description}
@@ -95,7 +105,7 @@ export default class TnrisDownloadTemplateDetails extends React.Component {
                         </div>) : (
                         <div className="mdc-layout-grid__inner">
                           <div className='mdc-layout-grid__cell mdc-layout-grid__cell--span-12'>
-                            {downloadMap}
+                            {map}
                             <Metadata collection={this.props.collection} />
                             {description}
                             {sourceCitation}

--- a/src/components/TnrisDownloadTemplate/TnrisDownloadTemplateDownload.jsx
+++ b/src/components/TnrisDownloadTemplate/TnrisDownloadTemplateDownload.jsx
@@ -415,24 +415,24 @@ export default class TnrisDownloadTemplateDownload extends React.Component {
   }
 
   render() {
-    if (window.innerWidth <= this.downloadBreakpoint) {
-      window.scrollTo(0,0);
-      return (
-        <div className='tnris-download-template-download'>
-          <div className="tnris-download-template-download__mobile">
-            <h3>Download Map Disabled for Mobile Devices</h3>
-            <p>
-              Due to the average size of data downloads and in consideration of user experience,
-              data downloads have been <strong>disabled</strong> for small browser windows and mobile devices.
-            </p>
-            <p>
-              Please visit this page with a desktop computer or increase the browser window size and refresh
-              the page to download this dataset.
-            </p>
-          </div>
-        </div>
-      )
-    }
+    // if (window.innerWidth <= this.downloadBreakpoint) {
+    //   window.scrollTo(0,0);
+    //   return (
+    //     <div className='tnris-download-template-download'>
+    //       <div className="tnris-download-template-download__mobile">
+    //         <h3>Download Map Disabled for Mobile Devices</h3>
+    //         <p>
+    //           Due to the average size of data downloads and in consideration of user experience,
+    //           data downloads have been <strong>disabled</strong> for small browser windows and mobile devices.
+    //         </p>
+    //         <p>
+    //           Please visit this page with a desktop computer or increase the browser window size and refresh
+    //           the page to download this dataset.
+    //         </p>
+    //       </div>
+    //     </div>
+    //   )
+    // }
 
     const { errorResources, loadingResources } = this.props;
     const loadingMessage = (

--- a/src/components/TnrisDownloadTemplate/TnrisDownloadTemplateDownload.jsx
+++ b/src/components/TnrisDownloadTemplate/TnrisDownloadTemplateDownload.jsx
@@ -415,25 +415,6 @@ export default class TnrisDownloadTemplateDownload extends React.Component {
   }
 
   render() {
-    // if (window.innerWidth <= this.downloadBreakpoint) {
-    //   window.scrollTo(0,0);
-    //   return (
-    //     <div className='tnris-download-template-download'>
-    //       <div className="tnris-download-template-download__mobile">
-    //         <h3>Download Map Disabled for Mobile Devices</h3>
-    //         <p>
-    //           Due to the average size of data downloads and in consideration of user experience,
-    //           data downloads have been <strong>disabled</strong> for small browser windows and mobile devices.
-    //         </p>
-    //         <p>
-    //           Please visit this page with a desktop computer or increase the browser window size and refresh
-    //           the page to download this dataset.
-    //         </p>
-    //       </div>
-    //     </div>
-    //   )
-    // }
-
     const { errorResources, loadingResources } = this.props;
     const loadingMessage = (
       // <div className='tnris-download-template-download'>

--- a/src/components/TnrisDownloadTemplate/TnrisDownloadTemplateDownload.jsx
+++ b/src/components/TnrisDownloadTemplate/TnrisDownloadTemplateDownload.jsx
@@ -112,7 +112,9 @@ export default class TnrisDownloadTemplateDownload extends React.Component {
     // add regular out-of-the-box controls if they dont already exist
     // prevents stacking/duplicating controls on component update
     if (!document.querySelector('.mapboxgl-ctrl-zoom-in')) {
-      map.addControl(new mapboxgl.NavigationControl(), 'top-left');
+      map.addControl(new mapboxgl.NavigationControl({
+        showCompass: false
+      }), 'top-left');
     }
     if (!document.querySelector('.mapboxgl-ctrl-fullscreen')) {
       map.addControl(new mapboxgl.FullscreenControl(), 'top-right');
@@ -199,12 +201,6 @@ export default class TnrisDownloadTemplateDownload extends React.Component {
         map.addControl(ctrlMenu, 'top-right')
       }
     }
-
-    // add tooltips for all map controls
-    document.querySelector('.mapboxgl-ctrl-zoom-in').setAttribute('title', 'Zoom In');
-    document.querySelector('.mapboxgl-ctrl-zoom-out').setAttribute('title', 'Zoom Out');
-    document.querySelector('.mapboxgl-ctrl-compass-arrow').setAttribute('title', 'Compass Arrow');
-    document.querySelector('.mapboxgl-ctrl-fullscreen').setAttribute('title', 'Fullscreen Map');
 
     // add custom controls to map
     const menuItems = document.querySelector('#download-menu');

--- a/src/sass/_collectionFilterMapView.scss
+++ b/src/sass/_collectionFilterMapView.scss
@@ -5,11 +5,11 @@ styles for component: CollectionFilterMapView
 .filter-map-view {
   height: 80vh;
 
-  h2 {
-    font-size: 1.7rem;
+  .mdc-top-app-bar__title {
     font-family: 'Roboto Condensed', sans-serif;
+    font-size: 1.7rem;
     color: $nest-text;
-    padding-bottom: 1px;
+    padding: 0;
   }
 
   .county-select__wrapper {

--- a/src/sass/_collectionTemplateDetails.scss
+++ b/src/sass/_collectionTemplateDetails.scss
@@ -10,10 +10,6 @@ shared styles for collection TemplateDetails components
   overflow-x: hidden;
   overflow-y: auto;
 
-  @media (min-width: $breakpoint-desktop) {
-    padding: 0 5%;
-  }
-
   // main template content container div - BEGIN
   .template-content-div {
     margin-bottom: 15px;
@@ -29,50 +25,6 @@ shared styles for collection TemplateDetails components
       white-space: pre-line;
     }
     // general elements - END
-
-    // used for description component (fade text) - used by all details templates
-    .fade-text {
-      position: relative;
-      max-height: 300px;
-      overflow: hidden;
-      transition: max-height 2s ease;
-
-      .mw-empty-elt {
-        display: none;
-      }
-
-      &.-expanded {
-        max-height: 100vh;
-      }
-    }
-
-    .mw-empty-elt {
-      display: none;
-    }
-
-    .fade-text:not(.-expanded)::after {
-      content: '';
-      position: absolute;
-      top: 0;
-      bottom: 0;
-      left: 0;
-      right: 0;
-      background: linear-gradient(rgba($main-background, 0), rgba($main-background, 1));
-    }
-
-    .expand {
-      width: 100%;
-      height: auto;
-      margin-top: 20px;
-      background-color: $primary-color;
-      color: $button-text;
-    }
-
-    .wiki-attribution {
-      font-size: 12px;
-      margin-bottom: 10px;
-    }
-    // end description component (fade-text)
 
     // source citation component
     .citation-container {

--- a/src/sass/_collectionTemplateDetails.scss
+++ b/src/sass/_collectionTemplateDetails.scss
@@ -6,9 +6,13 @@ shared styles for collection TemplateDetails components
 .tnris-order-template-details,
 .historical-aerial-template-details,
 .outside-entity-template-details {
-  padding: 50px 0 0 0;
+  margin: 50px 0 0 0;
   overflow-x: hidden;
   overflow-y: auto;
+
+  @media (min-width: $breakpoint-desktop) {
+    padding: 0 5%;
+  }
 
   // main template content container div - BEGIN
   .template-content-div {

--- a/src/sass/_collectionTemplates.scss
+++ b/src/sass/_collectionTemplates.scss
@@ -97,7 +97,7 @@ shared styles for collection base Template components
 
 // template images - used for download, historical and order
 .tnris-template-images {
-  max-width: 1200px;
+  max-width: 1400px;
   margin: 0 auto;
 
   // nested images (image carousel) component - BEGIN

--- a/src/sass/_collectionTemplates.scss
+++ b/src/sass/_collectionTemplates.scss
@@ -24,6 +24,7 @@ shared styles for collection base Template components
     .mdc-top-app-bar__title {
       font-family: 'Roboto Condensed', sans-serif;
       font-size: 1.7rem;
+      padding-left: 0;
       color: $nest-text;
     }
 

--- a/src/sass/_collectionTemplates.scss
+++ b/src/sass/_collectionTemplates.scss
@@ -18,7 +18,6 @@ shared styles for collection base Template components
   header {
     @include mdc-top-app-bar-fill-color($main-background);
     z-index: 3;
-    // position: relative;
     position: fixed;
 
     // collection title, show in left hand section

--- a/src/sass/_collectionTemplates.scss
+++ b/src/sass/_collectionTemplates.scss
@@ -24,20 +24,35 @@ shared styles for collection base Template components
     .mdc-top-app-bar__title {
       font-family: 'Roboto Condensed', sans-serif;
       font-size: 1.7rem;
-      padding-left: 0;
       color: $nest-text;
+      padding: 0;
+    }
+
+    // header left hand section, collection title
+    section.mdc-top-app-bar__section.mdc-top-app-bar__section--align-start {
+      width: auto;
+      padding: 8px 8px 8px 32px;
+
+      @media (max-width: $breakpoint-tablet) {
+        padding: 8px 8px 8px 24px;
+      }
     }
 
     // header right hand section, tabs and dropdown - BEGIN
     section.mdc-top-app-bar__section.mdc-top-app-bar__section--align-end {
       width: auto;
+      padding: 8px 32px 8px 8px;
+
+      @media (max-width: $breakpoint-tablet) {
+        padding: 8px 24px 8px 8px;
+      }
 
       // desktop tabs
       div.mdc-tab-bar {
         .mdc-tab {
           max-width: 86px;
-          margin-left: 15px;
-          margin-right: 15px;
+          margin-left: 10px;
+          margin-right: 10px;
           span {
             color: $nest-text-subtle;
           }
@@ -98,7 +113,7 @@ shared styles for collection base Template components
 
 // template images - used for download, historical and order
 .tnris-template-images {
-  max-width: 1400px;
+  max-width: 1300px;
   margin: 0 auto;
 
   // nested images (image carousel) component - BEGIN

--- a/src/sass/_contactTnrisForm.scss
+++ b/src/sass/_contactTnrisForm.scss
@@ -8,7 +8,7 @@ styles for component: ContactTnrisForm
   @include mdc-text-field-line-ripple-color($primary-color);
   @include mdc-text-field-textarea-stroke-color(rgba(0, 0, 0, 0.12));
 
-  margin: 20px 20px 20px 20px;
+  margin: 20px 20px;
   min-height: 200px;
   overflow-y: auto;
   overflow-x: hidden;

--- a/src/sass/_contactTnrisForm.scss
+++ b/src/sass/_contactTnrisForm.scss
@@ -8,13 +8,13 @@ styles for component: ContactTnrisForm
   @include mdc-text-field-line-ripple-color($primary-color);
   @include mdc-text-field-textarea-stroke-color(rgba(0, 0, 0, 0.12));
 
-  margin: 20px 20px;
+  padding: 24px;
   min-height: 200px;
   overflow-y: auto;
   overflow-x: hidden;
 
-  @media (min-width: $breakpoint-desktop) {
-    padding: 0 10%;
+  @media (max-width: $breakpoint-tablet) {
+    padding: 16px;
   }
 
   p.mdc-typography--body2 {

--- a/src/sass/_contactTnrisForm.scss
+++ b/src/sass/_contactTnrisForm.scss
@@ -8,10 +8,14 @@ styles for component: ContactTnrisForm
   @include mdc-text-field-line-ripple-color($primary-color);
   @include mdc-text-field-textarea-stroke-color(rgba(0, 0, 0, 0.12));
 
-  padding: 10px 20px 20px 20px;
+  margin: 20px 20px 20px 20px;
   min-height: 200px;
   overflow-y: auto;
   overflow-x: hidden;
+
+  @media (min-width: $breakpoint-desktop) {
+    padding: 0 10%;
+  }
 
   p.mdc-typography--body2 {
     margin-bottom: 6px;

--- a/src/sass/_header.scss
+++ b/src/sass/_header.scss
@@ -91,7 +91,7 @@ styles for component: Header
 
     #app-title {
       border: none;
-      padding: 0px 0px 0px 20px;
+      padding: 0px 0px 0px 12px;
       font-family: 'Roboto Condensed', sans-serif;
       color: $nest-text;
       background-color: rgba(0, 0, 0, 0);

--- a/src/sass/_orderCart.scss
+++ b/src/sass/_orderCart.scss
@@ -17,8 +17,12 @@ styles for component: OrderCart
     @include mdc-radio-checked-stroke-color($primary-color);
     @include mdc-radio-focus-indicator-color($primary-color)
 
-    padding: 15px;
+    margin: 20px 20px;
     color: $nest-text;
+
+    @media (min-width: $breakpoint-desktop) {
+      padding: 0 10%;
+    }
 
     .order-cart-data-items {
       .mdc-list-item {

--- a/src/sass/_orderTnrisDataForm.scss
+++ b/src/sass/_orderTnrisDataForm.scss
@@ -16,10 +16,14 @@ styles for component: OrderTnrisDataForm
     border-color: $nest-text;
   }
 
-  padding: 10px 20px 20px 20px;
+  margin: 20px 20px 20px 20px;
   min-height: 200px;
   overflow-y: auto;
   overflow-x: hidden;
+
+  @media (min-width: $breakpoint-desktop) {
+    padding: 0 10%;
+  }
 
   div.mdc-text-field {
     border-bottom-width: 1px;

--- a/src/sass/_orderTnrisDataForm.scss
+++ b/src/sass/_orderTnrisDataForm.scss
@@ -16,13 +16,13 @@ styles for component: OrderTnrisDataForm
     border-color: $nest-text;
   }
 
-  margin: 20px 20px;
+  padding: 24px;
   min-height: 200px;
   overflow-y: auto;
   overflow-x: hidden;
 
-  @media (min-width: $breakpoint-desktop) {
-    padding: 0 10%;
+  @media (max-width: $breakpoint-tablet) {
+    padding: 16px;
   }
 
   div.mdc-text-field {

--- a/src/sass/_orderTnrisDataForm.scss
+++ b/src/sass/_orderTnrisDataForm.scss
@@ -16,7 +16,7 @@ styles for component: OrderTnrisDataForm
     border-color: $nest-text;
   }
 
-  margin: 20px 20px 20px 20px;
+  margin: 20px 20px;
   min-height: 200px;
   overflow-y: auto;
   overflow-x: hidden;

--- a/src/sass/_tnrisDownloadTemplateDownload.scss
+++ b/src/sass/_tnrisDownloadTemplateDownload.scss
@@ -54,12 +54,6 @@ styles for component: TnrisDownloadTemplateDownload
     }
   }
 
-  .tnris-download-template-download__mobile {
-    background: $main-background;
-    color: $nest-text;
-    padding: 8px 12px 8px 12px;
-  }
-
   .tnris-download-template-download__loading {
     overflow: hidden;
 

--- a/src/sass/_tnrisDownloadTemplateDownload.scss
+++ b/src/sass/_tnrisDownloadTemplateDownload.scss
@@ -54,6 +54,12 @@ styles for component: TnrisDownloadTemplateDownload
     }
   }
 
+  .tnris-download-template-download__mobile {
+    background: $main-background;
+    color: $nest-text;
+    padding: 8px 12px 8px 12px;
+  }
+
   .tnris-download-template-download__loading {
     overflow: hidden;
 

--- a/src/sass/_tnrisDownloadTemplateDownload.scss
+++ b/src/sass/_tnrisDownloadTemplateDownload.scss
@@ -57,7 +57,7 @@ styles for component: TnrisDownloadTemplateDownload
   .tnris-download-template-download__mobile {
     background: $main-background;
     color: $nest-text;
-    padding: 20px;
+    padding: 8px 12px 8px 12px;
   }
 
   .tnris-download-template-download__loading {


### PR DESCRIPTION
cleans up some sass and component stuff, tried to get sass for collection views (details, images, forms) to all be pretty much the same in header and padding, etc. disabled county selector in the geo filter on mobile devices (issue #237). disabled navigation compass control in all maps - geoFilter, coverage area, and download maps - closes issue #134. 

this PR also addresses issue #219 which is actually just an idea that i had for mobile devices. instead of just a disabled downloads note, insert the coverage map with an additional note to say that downloads have been disabled but the map gives the user at least something geospatial to look at. this can be changed or not implemented but i thought it was a decent idea. let me know what you guys think.