### PR TITLE
Feature/county name for scanned historical index

### DIFF
--- a/src/components/DialogTemplateListItems/Ls4Links.jsx
+++ b/src/components/DialogTemplateListItems/Ls4Links.jsx
@@ -27,6 +27,7 @@ export default class Ls4Links extends React.Component {
   render() {
     let scanLinks;
     const scans = this.props.scans ? JSON.parse("[" + this.props.scans + "]") : [];
+
     if (scans.length > 0) {
       scanLinks = (
         <div className="ls4-scans">
@@ -48,6 +49,9 @@ export default class Ls4Links extends React.Component {
                   <div>{scan.size}</div>
                   <div>
                     <a href={scan.link} target="_blank" rel="noopener noreferrer">Download</a>
+                  </div>
+                  <div>
+                    {scan.link.split("/")[4]}
                   </div>
                 </li>
               )}

--- a/src/components/DialogTemplateListItems/Ls4Links.jsx
+++ b/src/components/DialogTemplateListItems/Ls4Links.jsx
@@ -46,12 +46,10 @@ export default class Ls4Links extends React.Component {
               return (
                 <li key={index} className={odd}>
                   <div>Sheet #{scan.sheet}</div>
+                  <div>{scan.link.split('/')[5]}</div>
                   <div>{scan.size}</div>
                   <div>
                     <a href={scan.link} target="_blank" rel="noopener noreferrer">Download</a>
-                  </div>
-                  <div>
-                    {scan.link.split("/")[4]}
                   </div>
                 </li>
               )}


### PR DESCRIPTION
resolves issue #189 

- split url string to get county name to put next to each scanned index available for download so user knows which sheet goes with which county
- @adambreznicky updated all photo index scanned ls4 link urls to be the same structure so the simple frontend code will always grab the correct position in the url string array to label each download with the correct county name